### PR TITLE
Support Jacobian and Hessian as `LinearOperator`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,5 @@ dependencies:
   # Dev
   - pytest
   - ruff
+  - mypy
+  - scipy-stubs

--- a/notebooks/01_repr.ipynb
+++ b/notebooks/01_repr.ipynb
@@ -6,11 +6,11 @@
    "id": "ec5a23f6-1939-4bd6-9ddc-a33798bbe64f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:33:46.758268Z",
-     "iopub.status.busy": "2025-07-23T16:33:46.757817Z",
-     "iopub.status.idle": "2025-07-23T16:33:47.097990Z",
-     "shell.execute_reply": "2025-07-23T16:33:47.097359Z",
-     "shell.execute_reply.started": "2025-07-23T16:33:46.758225Z"
+     "iopub.execute_input": "2025-07-30T20:52:19.824029Z",
+     "iopub.status.busy": "2025-07-30T20:52:19.823406Z",
+     "iopub.status.idle": "2025-07-30T20:52:20.143754Z",
+     "shell.execute_reply": "2025-07-30T20:52:20.143144Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:19.823992Z"
     }
    },
    "outputs": [],
@@ -25,11 +25,11 @@
    "id": "9ec050b8-c948-41cb-b13d-d8e510fbfa4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:33:47.098707Z",
-     "iopub.status.busy": "2025-07-23T16:33:47.098476Z",
-     "iopub.status.idle": "2025-07-23T16:33:47.103135Z",
-     "shell.execute_reply": "2025-07-23T16:33:47.102446Z",
-     "shell.execute_reply.started": "2025-07-23T16:33:47.098689Z"
+     "iopub.execute_input": "2025-07-30T20:52:20.144493Z",
+     "iopub.status.busy": "2025-07-30T20:52:20.144251Z",
+     "iopub.status.idle": "2025-07-30T20:52:20.148783Z",
+     "shell.execute_reply": "2025-07-30T20:52:20.148005Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:20.144474Z"
     }
    },
    "outputs": [],
@@ -60,11 +60,11 @@
    "id": "00c39dc7-9da0-4a44-8950-b63c31f42cee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:33:47.103986Z",
-     "iopub.status.busy": "2025-07-23T16:33:47.103782Z",
-     "iopub.status.idle": "2025-07-23T16:33:47.125139Z",
-     "shell.execute_reply": "2025-07-23T16:33:47.124462Z",
-     "shell.execute_reply.started": "2025-07-23T16:33:47.103967Z"
+     "iopub.execute_input": "2025-07-30T20:52:20.149688Z",
+     "iopub.status.busy": "2025-07-30T20:52:20.149477Z",
+     "iopub.status.idle": "2025-07-30T20:52:20.163550Z",
+     "shell.execute_reply": "2025-07-30T20:52:20.163086Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:20.149668Z"
     }
    },
    "outputs": [
@@ -94,11 +94,11 @@
    "id": "ab16bcf5-8529-4b01-9ce5-f0060110e73d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:33:47.126189Z",
-     "iopub.status.busy": "2025-07-23T16:33:47.125906Z",
-     "iopub.status.idle": "2025-07-23T16:33:47.138775Z",
-     "shell.execute_reply": "2025-07-23T16:33:47.137943Z",
-     "shell.execute_reply.started": "2025-07-23T16:33:47.126167Z"
+     "iopub.execute_input": "2025-07-30T20:52:20.164529Z",
+     "iopub.status.busy": "2025-07-30T20:52:20.164253Z",
+     "iopub.status.idle": "2025-07-30T20:52:20.176723Z",
+     "shell.execute_reply": "2025-07-30T20:52:20.176199Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:20.164498Z"
     }
    },
    "outputs": [
@@ -128,11 +128,11 @@
    "id": "1da4940c-8fba-4aef-ba71-6979b31e8265",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:33:47.139980Z",
-     "iopub.status.busy": "2025-07-23T16:33:47.139693Z",
-     "iopub.status.idle": "2025-07-23T16:33:47.147939Z",
-     "shell.execute_reply": "2025-07-23T16:33:47.147301Z",
-     "shell.execute_reply.started": "2025-07-23T16:33:47.139950Z"
+     "iopub.execute_input": "2025-07-30T20:52:20.177657Z",
+     "iopub.status.busy": "2025-07-30T20:52:20.177390Z",
+     "iopub.status.idle": "2025-07-30T20:52:20.189575Z",
+     "shell.execute_reply": "2025-07-30T20:52:20.189011Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:20.177631Z"
     }
    },
    "outputs": [
@@ -162,11 +162,11 @@
    "id": "4ed58d30-7f47-48d4-8d26-479963785f76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:33:47.150516Z",
-     "iopub.status.busy": "2025-07-23T16:33:47.150155Z",
-     "iopub.status.idle": "2025-07-23T16:33:47.157437Z",
-     "shell.execute_reply": "2025-07-23T16:33:47.156882Z",
-     "shell.execute_reply.started": "2025-07-23T16:33:47.150486Z"
+     "iopub.execute_input": "2025-07-30T20:52:20.190927Z",
+     "iopub.status.busy": "2025-07-30T20:52:20.190733Z",
+     "iopub.status.idle": "2025-07-30T20:52:20.202380Z",
+     "shell.execute_reply": "2025-07-30T20:52:20.201671Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:20.190909Z"
     }
    },
    "outputs": [
@@ -195,11 +195,11 @@
    "id": "0eab53d0-ff76-4866-8da6-9f7a77848f5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:33:47.158356Z",
-     "iopub.status.busy": "2025-07-23T16:33:47.158093Z",
-     "iopub.status.idle": "2025-07-23T16:33:47.167332Z",
-     "shell.execute_reply": "2025-07-23T16:33:47.166521Z",
-     "shell.execute_reply.started": "2025-07-23T16:33:47.158327Z"
+     "iopub.execute_input": "2025-07-30T20:52:20.203301Z",
+     "iopub.status.busy": "2025-07-30T20:52:20.203064Z",
+     "iopub.status.idle": "2025-07-30T20:52:20.214354Z",
+     "shell.execute_reply": "2025-07-30T20:52:20.213768Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:20.203277Z"
     }
    },
    "outputs": [
@@ -228,11 +228,11 @@
    "id": "d3a42b97-a3f4-41c9-a5a1-0b06e937f361",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:33:47.168935Z",
-     "iopub.status.busy": "2025-07-23T16:33:47.168295Z",
-     "iopub.status.idle": "2025-07-23T16:33:47.174762Z",
-     "shell.execute_reply": "2025-07-23T16:33:47.174144Z",
-     "shell.execute_reply.started": "2025-07-23T16:33:47.168899Z"
+     "iopub.execute_input": "2025-07-30T20:52:20.215215Z",
+     "iopub.status.busy": "2025-07-30T20:52:20.215016Z",
+     "iopub.status.idle": "2025-07-30T20:52:20.225723Z",
+     "shell.execute_reply": "2025-07-30T20:52:20.225066Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:20.215197Z"
     }
    },
    "outputs": [
@@ -258,11 +258,11 @@
    "id": "491b1048-a8fc-47eb-8d25-a75d292dca01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:33:47.175822Z",
-     "iopub.status.busy": "2025-07-23T16:33:47.175516Z",
-     "iopub.status.idle": "2025-07-23T16:33:47.182286Z",
-     "shell.execute_reply": "2025-07-23T16:33:47.181599Z",
-     "shell.execute_reply.started": "2025-07-23T16:33:47.175793Z"
+     "iopub.execute_input": "2025-07-30T20:52:20.226818Z",
+     "iopub.status.busy": "2025-07-30T20:52:20.226523Z",
+     "iopub.status.idle": "2025-07-30T20:52:20.238426Z",
+     "shell.execute_reply": "2025-07-30T20:52:20.237728Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:20.226789Z"
     }
    },
    "outputs": [

--- a/notebooks/02_linear-regressor.ipynb
+++ b/notebooks/02_linear-regressor.ipynb
@@ -14,11 +14,11 @@
    "id": "bba9bf32-da93-4100-9ee1-0983a1450bb4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.162766Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.162477Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.457302Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.456634Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.162740Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.459985Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.459429Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.774725Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.774129Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.459914Z"
     }
    },
    "outputs": [],
@@ -35,11 +35,11 @@
    "id": "afa3d214-09d3-4a0f-a402-5793d8b308b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.458171Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.457850Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.464413Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.463810Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.458150Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.775447Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.775215Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.781924Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.781139Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.775427Z"
     }
    },
    "outputs": [
@@ -68,11 +68,11 @@
    "id": "5485a55c-9727-4260-b590-1ea243dba484",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.465690Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.465183Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.470243Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.469503Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.465658Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.782982Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.782693Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.793345Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.792817Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.782954Z"
     }
    },
    "outputs": [],
@@ -89,11 +89,11 @@
    "id": "66458a9c-5e01-4a75-8fd0-fd149f447992",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.471784Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.471036Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.477183Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.476394Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.471754Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.794230Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.793952Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.806632Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.806178Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.794204Z"
     }
    },
    "outputs": [
@@ -126,11 +126,11 @@
    "id": "ad91f721-72a9-485b-9043-d85a2a220b7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.478617Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.478136Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.481786Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.481171Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.478585Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.807375Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.807153Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.818483Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.817813Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.807357Z"
     }
    },
    "outputs": [],
@@ -144,11 +144,11 @@
    "id": "04636169-320a-4f1e-ab42-1b083b0111dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.484530Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.484169Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.488248Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.487607Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.484499Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.820404Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.820144Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.830669Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.829868Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.820383Z"
     }
    },
    "outputs": [],
@@ -164,11 +164,11 @@
    "id": "8da79647-eb17-4177-afb9-776f3cc4ffc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.489008Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.488823Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.494004Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.493302Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.488990Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.831627Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.831361Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.844066Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.843406Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.831606Z"
     }
    },
    "outputs": [
@@ -197,11 +197,11 @@
    "id": "d7bb890a-2958-4ea4-aa64-413f57c7b63e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.494964Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.494775Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.498989Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.498435Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.494946Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.844939Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.844732Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.857196Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.856558Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.844919Z"
     }
    },
    "outputs": [
@@ -235,11 +235,11 @@
    "id": "d4bac3a2-49d5-4592-a793-72789ec31a5c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.499864Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.499608Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.503546Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.502791Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.499839Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.858321Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.858017Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.869161Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.868396Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.858290Z"
     }
    },
    "outputs": [],
@@ -253,11 +253,11 @@
    "id": "c3369162-abe9-4fb9-9294-69277e50ef13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.504629Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.504410Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.509980Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.509313Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.504610Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.870219Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.869922Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.883547Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.882801Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.870189Z"
     }
    },
    "outputs": [],
@@ -272,11 +272,11 @@
    "id": "c1fed88c-9c34-4ee3-8208-e7b50c2ec678",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.511017Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.510748Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.516580Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.515961Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.510988Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.884710Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.884403Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.898818Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.898199Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.884677Z"
     }
    },
    "outputs": [
@@ -304,11 +304,11 @@
    "id": "54a8ef70-6e5f-4000-ad2f-658dbffd83f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.517980Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.517437Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.521372Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.520615Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.517948Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.899651Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.899431Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.908624Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.907938Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.899631Z"
     }
    },
    "outputs": [],
@@ -322,11 +322,11 @@
    "id": "b05f913f-dcfa-4bca-a277-b9cf5c9de6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.522796Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.522211Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.528239Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.527568Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.522763Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.909634Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.909424Z",
+     "iopub.status.idle": "2025-07-30T20:52:29.921862Z",
+     "shell.execute_reply": "2025-07-30T20:52:29.921068Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.909609Z"
     }
    },
    "outputs": [
@@ -366,11 +366,11 @@
    "id": "5f36ec3b-0380-4eeb-b01a-3191c12b70f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.529292Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.528997Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.627862Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.627203Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.529263Z"
+     "iopub.execute_input": "2025-07-30T20:52:29.923142Z",
+     "iopub.status.busy": "2025-07-30T20:52:29.922626Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.069142Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.068322Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:29.923110Z"
     }
    },
    "outputs": [],
@@ -384,11 +384,11 @@
    "id": "ba337ea8-0afb-46aa-b107-07bcf86a8324",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.628808Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.628584Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.732988Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.732442Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.628789Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.069987Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.069762Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.173869Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.173308Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.069968Z"
     }
    },
    "outputs": [
@@ -429,11 +429,11 @@
    "id": "d5cf83b5-6cbd-42d1-9513-d3ca38464b72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.733769Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.733576Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.737193Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.736343Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.733751Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.174838Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.174592Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.177751Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.177208Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.174807Z"
     }
    },
    "outputs": [],
@@ -448,11 +448,11 @@
    "id": "d25be88b-3134-447a-b003-c80dddff3166",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.738321Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.737986Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.746221Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.745545Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.738290Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.178706Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.178453Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.191244Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.190638Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.178679Z"
     }
    },
    "outputs": [
@@ -484,11 +484,11 @@
    "id": "50cb98a1-1fc8-4378-a517-09ed910ce1c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.747350Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.746844Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.772910Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.772218Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.747323Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.192271Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.191977Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.230668Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.229980Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.192243Z"
     }
    },
    "outputs": [
@@ -524,11 +524,11 @@
    "id": "45a7c13a-79ea-445f-b63d-b551787ebc20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.773621Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.773429Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.776749Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.776006Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.773602Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.231749Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.231460Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.235417Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.234668Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.231719Z"
     }
    },
    "outputs": [],
@@ -543,11 +543,11 @@
    "id": "094fbf19-b676-4aba-8e23-b93abb8b2431",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.777661Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.777406Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.781976Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.781330Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.777641Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.236527Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.236224Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.248686Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.247993Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.236499Z"
     }
    },
    "outputs": [
@@ -579,11 +579,11 @@
    "id": "65235b83-fd51-4f52-b7ba-3c0dc2a35fe2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.785421Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.785122Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.813204Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.812588Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.785401Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.252702Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.252342Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.281437Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.280805Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.252667Z"
     }
    },
    "outputs": [
@@ -620,11 +620,11 @@
    "id": "45df89b6-58fc-472c-bfa6-96f1d3c7cc5c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.814007Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.813806Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.816969Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.816220Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.813988Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.282293Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.282068Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.285454Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.284697Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.282272Z"
     }
    },
    "outputs": [],
@@ -639,11 +639,11 @@
    "id": "2e9d2ee1-bfd9-4c3d-9865-f63d08a25b07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.818092Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.817803Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.823002Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.822409Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.818063Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.286394Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.286114Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.297902Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.297251Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.286366Z"
     }
    },
    "outputs": [
@@ -683,18 +683,18 @@
    "id": "34372a3f-ff42-435f-9423-a4f99712fd9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.824170Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.823877Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.828391Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.827749Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.824139Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.299118Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.298630Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.318171Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.315426Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.299097Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<inversion_ideas.minimizer.ConjugateGradient at 0x7fe0bd1f34d0>"
+       "<inversion_ideas.minimizer.ConjugateGradient at 0x7ff7f21eb4d0>"
       ]
      },
      "execution_count": 24,
@@ -713,11 +713,11 @@
    "id": "f3f52071-c2c5-4016-9d61-cd2f3b781698",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.829433Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.829080Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.835198Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.834411Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.829406Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.322822Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.321005Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.341516Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.339856Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.322710Z"
     }
    },
    "outputs": [],
@@ -731,11 +731,11 @@
    "id": "e41d3e15-1a74-42b9-9583-cacb8aeceadc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:31:24.836331Z",
-     "iopub.status.busy": "2025-07-30T20:31:24.836023Z",
-     "iopub.status.idle": "2025-07-30T20:31:24.840715Z",
-     "shell.execute_reply": "2025-07-30T20:31:24.839928Z",
-     "shell.execute_reply.started": "2025-07-30T20:31:24.836300Z"
+     "iopub.execute_input": "2025-07-30T20:52:30.343695Z",
+     "iopub.status.busy": "2025-07-30T20:52:30.343040Z",
+     "iopub.status.idle": "2025-07-30T20:52:30.355385Z",
+     "shell.execute_reply": "2025-07-30T20:52:30.354593Z",
+     "shell.execute_reply.started": "2025-07-30T20:52:30.343643Z"
     }
    },
    "outputs": [

--- a/notebooks/02_linear-regressor.ipynb
+++ b/notebooks/02_linear-regressor.ipynb
@@ -14,11 +14,11 @@
    "id": "bba9bf32-da93-4100-9ee1-0983a1450bb4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.155595Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.155259Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.474160Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.473519Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.155567Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.162766Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.162477Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.457302Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.456634Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.162740Z"
     }
    },
    "outputs": [],
@@ -35,11 +35,11 @@
    "id": "afa3d214-09d3-4a0f-a402-5793d8b308b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.474938Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.474675Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.482286Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.481583Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.474906Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.458171Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.457850Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.464413Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.463810Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.458150Z"
     }
    },
    "outputs": [
@@ -68,11 +68,11 @@
    "id": "5485a55c-9727-4260-b590-1ea243dba484",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.483030Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.482816Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.497131Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.496469Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.483009Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.465690Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.465183Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.470243Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.469503Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.465658Z"
     }
    },
    "outputs": [],
@@ -89,11 +89,11 @@
    "id": "66458a9c-5e01-4a75-8fd0-fd149f447992",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.497947Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.497748Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.508573Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.507971Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.497928Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.471784Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.471036Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.477183Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.476394Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.471754Z"
     }
    },
    "outputs": [
@@ -126,11 +126,11 @@
    "id": "ad91f721-72a9-485b-9043-d85a2a220b7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.509535Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.509229Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.516291Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.515719Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.509506Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.478617Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.478136Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.481786Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.481171Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.478585Z"
     }
    },
    "outputs": [],
@@ -144,11 +144,11 @@
    "id": "04636169-320a-4f1e-ab42-1b083b0111dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.518726Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.518444Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.532959Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.532187Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.518704Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.484530Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.484169Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.488248Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.487607Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.484499Z"
     }
    },
    "outputs": [],
@@ -164,11 +164,11 @@
    "id": "8da79647-eb17-4177-afb9-776f3cc4ffc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.533907Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.533596Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.554730Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.553980Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.533877Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.489008Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.488823Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.494004Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.493302Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.488990Z"
     }
    },
    "outputs": [
@@ -197,11 +197,11 @@
    "id": "d7bb890a-2958-4ea4-aa64-413f57c7b63e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.556085Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.555613Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.563549Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.562993Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.556048Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.494964Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.494775Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.498989Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.498435Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.494946Z"
     }
    },
    "outputs": [
@@ -235,11 +235,11 @@
    "id": "d4bac3a2-49d5-4592-a793-72789ec31a5c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.564296Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.564102Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.570018Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.569178Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.564276Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.499864Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.499608Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.503546Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.502791Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.499839Z"
     }
    },
    "outputs": [],
@@ -253,11 +253,11 @@
    "id": "c3369162-abe9-4fb9-9294-69277e50ef13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.571299Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.570942Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.580311Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.579716Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.571263Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.504629Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.504410Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.509980Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.509313Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.504610Z"
     }
    },
    "outputs": [],
@@ -272,11 +272,11 @@
    "id": "c1fed88c-9c34-4ee3-8208-e7b50c2ec678",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.581353Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.581065Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.590994Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.590280Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.581322Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.511017Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.510748Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.516580Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.515961Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.510988Z"
     }
    },
    "outputs": [
@@ -304,11 +304,11 @@
    "id": "54a8ef70-6e5f-4000-ad2f-658dbffd83f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.592437Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.591894Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.598507Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.597755Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.592402Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.517980Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.517437Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.521372Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.520615Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.517948Z"
     }
    },
    "outputs": [],
@@ -322,11 +322,11 @@
    "id": "b05f913f-dcfa-4bca-a277-b9cf5c9de6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.599803Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.599475Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.607380Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.606608Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.599770Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.522796Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.522211Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.528239Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.527568Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.522763Z"
     }
    },
    "outputs": [
@@ -366,11 +366,11 @@
    "id": "5f36ec3b-0380-4eeb-b01a-3191c12b70f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.608344Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.608101Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.720380Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.719607Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.608321Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.529292Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.528997Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.627862Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.627203Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.529263Z"
     }
    },
    "outputs": [],
@@ -384,11 +384,11 @@
    "id": "ba337ea8-0afb-46aa-b107-07bcf86a8324",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.721392Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.721124Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.840698Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.839910Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.721368Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.628808Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.628584Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.732988Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.732442Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.628789Z"
     }
    },
    "outputs": [
@@ -429,11 +429,11 @@
    "id": "d5cf83b5-6cbd-42d1-9513-d3ca38464b72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.841743Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.841366Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.845304Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.844651Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.841708Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.733769Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.733576Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.737193Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.736343Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.733751Z"
     }
    },
    "outputs": [],
@@ -448,11 +448,11 @@
    "id": "d25be88b-3134-447a-b003-c80dddff3166",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.846649Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.845928Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.855068Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.854320Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.846613Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.738321Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.737986Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.746221Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.745545Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.738290Z"
     }
    },
    "outputs": [
@@ -484,11 +484,11 @@
    "id": "50cb98a1-1fc8-4378-a517-09ed910ce1c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.856190Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.855868Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.891088Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.890143Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.856166Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.747350Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.746844Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.772910Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.772218Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.747323Z"
     }
    },
    "outputs": [
@@ -498,12 +498,12 @@
        " message: Optimization terminated successfully.\n",
        " success: True\n",
        "  status: 0\n",
-       "     fun: 0.3715960311156836\n",
+       "     fun: 0.3715960311156822\n",
        "       x: [ 8.133e-01  6.592e-01  2.473e-01  1.963e-01  3.237e-01\n",
        "            1.472e-01  3.195e-01  2.524e-01  5.222e-01  9.218e-01]\n",
        "     nit: 12\n",
-       "     jac: [ 3.612e-12  7.223e-12  7.137e-12  4.872e-12  5.592e-12\n",
-       "            6.519e-12  6.291e-12  7.993e-12  6.342e-12  8.719e-12]\n",
+       "     jac: [ 8.321e-13 -8.337e-13 -1.028e-12 -2.157e-14 -2.755e-13\n",
+       "           -4.928e-13 -8.490e-13 -1.512e-12 -5.860e-13 -1.837e-12]\n",
        "    nfev: 24\n",
        "    njev: 24"
       ]
@@ -524,11 +524,11 @@
    "id": "45a7c13a-79ea-445f-b63d-b551787ebc20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.892479Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.892090Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.895990Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.895283Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.892440Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.773621Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.773429Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.776749Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.776006Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.773602Z"
     }
    },
    "outputs": [],
@@ -543,11 +543,11 @@
    "id": "094fbf19-b676-4aba-8e23-b93abb8b2431",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.897061Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.896763Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.906265Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.905380Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.897031Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.777661Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.777406Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.781976Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.781330Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.777641Z"
     }
    },
    "outputs": [
@@ -579,11 +579,11 @@
    "id": "65235b83-fd51-4f52-b7ba-3c0dc2a35fe2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.909944Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.909618Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.951403Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.950711Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.909917Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.785421Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.785122Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.813204Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.812588Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.785401Z"
     }
    },
    "outputs": [
@@ -593,7 +593,7 @@
        " message: Optimization terminated successfully.\n",
        " success: True\n",
        "  status: 0\n",
-       "     fun: 0.3715960311172809\n",
+       "     fun: 0.37159603111728207\n",
        "       x: [ 8.133e-01  6.592e-01  2.473e-01  1.963e-01  3.237e-01\n",
        "            1.472e-01  3.195e-01  2.524e-01  5.222e-01  9.218e-01]\n",
        "     nit: 10\n",
@@ -601,7 +601,7 @@
        "           -1.612e-04  8.816e-05  7.859e-06  3.653e-04 -1.935e-04]\n",
        "    nfev: 11\n",
        "    njev: 11\n",
-       "    nhev: 10"
+       "    nhev: 28"
       ]
      },
      "execution_count": 21,
@@ -620,11 +620,11 @@
    "id": "45df89b6-58fc-472c-bfa6-96f1d3c7cc5c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.952542Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.952189Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.956340Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.955516Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.952505Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.814007Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.813806Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.816969Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.816220Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.813988Z"
     }
    },
    "outputs": [],
@@ -639,11 +639,11 @@
    "id": "2e9d2ee1-bfd9-4c3d-9865-f63d08a25b07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.957539Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.957156Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.966604Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.965778Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.957497Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.818092Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.817803Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.823002Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.822409Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.818063Z"
     }
    },
    "outputs": [
@@ -683,18 +683,18 @@
    "id": "34372a3f-ff42-435f-9423-a4f99712fd9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.967786Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.967434Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.975769Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.974822Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.967749Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.824170Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.823877Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.828391Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.827749Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.824139Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<inversion_ideas.minimizer.ConjugateGradient at 0x7fd33143a7b0>"
+       "<inversion_ideas.minimizer.ConjugateGradient at 0x7fe0bd1f34d0>"
       ]
      },
      "execution_count": 24,
@@ -713,11 +713,11 @@
    "id": "f3f52071-c2c5-4016-9d61-cd2f3b781698",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.977062Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.976761Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.983704Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.983111Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.977038Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.829433Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.829080Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.835198Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.834411Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.829406Z"
     }
    },
    "outputs": [],
@@ -731,11 +731,11 @@
    "id": "e41d3e15-1a74-42b9-9583-cacb8aeceadc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.984622Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.984347Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.992186Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.991340Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.984589Z"
+     "iopub.execute_input": "2025-07-30T20:31:24.836331Z",
+     "iopub.status.busy": "2025-07-30T20:31:24.836023Z",
+     "iopub.status.idle": "2025-07-30T20:31:24.840715Z",
+     "shell.execute_reply": "2025-07-30T20:31:24.839928Z",
+     "shell.execute_reply.started": "2025-07-30T20:31:24.836300Z"
     }
    },
    "outputs": [

--- a/notebooks/03_beta-cooling.ipynb
+++ b/notebooks/03_beta-cooling.ipynb
@@ -14,11 +14,11 @@
    "id": "fdaf3332-6fe1-4381-a1a3-697c494f749d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:09.627741Z",
-     "iopub.status.busy": "2025-07-23T16:44:09.627426Z",
-     "iopub.status.idle": "2025-07-23T16:44:09.910812Z",
-     "shell.execute_reply": "2025-07-23T16:44:09.910192Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:09.627707Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.262897Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.262542Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.560417Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.559889Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.262865Z"
     }
    },
    "outputs": [],
@@ -50,11 +50,11 @@
    "id": "761c849a-17cc-450c-9a30-cfb87f1cf489",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:09.911698Z",
-     "iopub.status.busy": "2025-07-23T16:44:09.911364Z",
-     "iopub.status.idle": "2025-07-23T16:44:09.920852Z",
-     "shell.execute_reply": "2025-07-23T16:44:09.920191Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:09.911671Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.561117Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.560892Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.568079Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.567324Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.561098Z"
     }
    },
    "outputs": [
@@ -83,11 +83,11 @@
    "id": "9f3eda31-8cc5-4c02-ac69-ba3396dca6c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:09.921889Z",
-     "iopub.status.busy": "2025-07-23T16:44:09.921581Z",
-     "iopub.status.idle": "2025-07-23T16:44:09.939306Z",
-     "shell.execute_reply": "2025-07-23T16:44:09.937380Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:09.921859Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.569207Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.568912Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.573072Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.572366Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.569179Z"
     }
    },
    "outputs": [],
@@ -104,11 +104,11 @@
    "id": "1e087215-ac6b-4fa1-b79d-537ef859331f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:09.942148Z",
-     "iopub.status.busy": "2025-07-23T16:44:09.941423Z",
-     "iopub.status.idle": "2025-07-23T16:44:09.951928Z",
-     "shell.execute_reply": "2025-07-23T16:44:09.950798Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:09.942073Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.574060Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.573784Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.579076Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.578575Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.574033Z"
     }
    },
    "outputs": [
@@ -149,11 +149,11 @@
    "id": "f30b705a-678e-46e2-ac18-58d8043b1a66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:09.953785Z",
-     "iopub.status.busy": "2025-07-23T16:44:09.953297Z",
-     "iopub.status.idle": "2025-07-23T16:44:09.961178Z",
-     "shell.execute_reply": "2025-07-23T16:44:09.959900Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:09.953736Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.579781Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.579604Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.583356Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.582620Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.579763Z"
     }
    },
    "outputs": [],
@@ -169,11 +169,11 @@
    "id": "46ef1d97-1373-4267-b4dd-dbea3b81fb48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:09.966200Z",
-     "iopub.status.busy": "2025-07-23T16:44:09.965352Z",
-     "iopub.status.idle": "2025-07-23T16:44:09.971435Z",
-     "shell.execute_reply": "2025-07-23T16:44:09.970266Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:09.966163Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.585855Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.585553Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.589160Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.588544Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.585826Z"
     }
    },
    "outputs": [],
@@ -195,11 +195,11 @@
    "id": "114370c2-238f-4b96-b2f0-67254235b849",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:09.973042Z",
-     "iopub.status.busy": "2025-07-23T16:44:09.972631Z",
-     "iopub.status.idle": "2025-07-23T16:44:09.983294Z",
-     "shell.execute_reply": "2025-07-23T16:44:09.982597Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:09.973013Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.589988Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.589679Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.598115Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.597481Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.589970Z"
     }
    },
    "outputs": [
@@ -229,11 +229,11 @@
    "id": "2e9d2ee1-bfd9-4c3d-9865-f63d08a25b07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:09.984132Z",
-     "iopub.status.busy": "2025-07-23T16:44:09.983892Z",
-     "iopub.status.idle": "2025-07-23T16:44:09.990859Z",
-     "shell.execute_reply": "2025-07-23T16:44:09.990078Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:09.984112Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.599164Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.598913Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.604042Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.603316Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.599136Z"
     }
    },
    "outputs": [
@@ -281,11 +281,11 @@
    "id": "30fe08ba-6e38-49ce-af5b-5e8d66302e75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:09.991929Z",
-     "iopub.status.busy": "2025-07-23T16:44:09.991609Z",
-     "iopub.status.idle": "2025-07-23T16:44:09.997141Z",
-     "shell.execute_reply": "2025-07-23T16:44:09.996406Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:09.991899Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.605131Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.604849Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.608324Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.607714Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.605103Z"
     }
    },
    "outputs": [],
@@ -299,11 +299,11 @@
    "id": "9d48ed76-24c5-45dc-aa27-6533b2e84cd4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:09.998098Z",
-     "iopub.status.busy": "2025-07-23T16:44:09.997841Z",
-     "iopub.status.idle": "2025-07-23T16:44:10.025290Z",
-     "shell.execute_reply": "2025-07-23T16:44:10.024544Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:09.998069Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.609287Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.609075Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.637155Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.636248Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.609269Z"
     }
    },
    "outputs": [
@@ -375,11 +375,11 @@
    "id": "3765ea4f-11dc-432a-8cf9-5df925789771",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:10.026141Z",
-     "iopub.status.busy": "2025-07-23T16:44:10.025870Z",
-     "iopub.status.idle": "2025-07-23T16:44:10.030525Z",
-     "shell.execute_reply": "2025-07-23T16:44:10.029851Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:10.026120Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.638296Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.637992Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.643245Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.642613Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.638266Z"
     }
    },
    "outputs": [],
@@ -420,11 +420,11 @@
    "id": "cfbd9de0-0cac-48e8-bd7b-ce64b8517083",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:10.031538Z",
-     "iopub.status.busy": "2025-07-23T16:44:10.031253Z",
-     "iopub.status.idle": "2025-07-23T16:44:10.037228Z",
-     "shell.execute_reply": "2025-07-23T16:44:10.036699Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:10.031501Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.644222Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.643970Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.647710Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.647010Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.644195Z"
     }
    },
    "outputs": [],
@@ -438,11 +438,11 @@
    "id": "d0a69baf-9a5f-4a5f-803c-42627ff11527",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:10.037958Z",
-     "iopub.status.busy": "2025-07-23T16:44:10.037768Z",
-     "iopub.status.idle": "2025-07-23T16:44:10.068034Z",
-     "shell.execute_reply": "2025-07-23T16:44:10.067452Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:10.037939Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.649159Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.648592Z",
+     "iopub.status.idle": "2025-07-30T21:09:08.676010Z",
+     "shell.execute_reply": "2025-07-30T21:09:08.675416Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.649128Z"
     }
    },
    "outputs": [
@@ -489,11 +489,11 @@
    "id": "42c55ccb-bbc4-47b1-b524-5d9a91e13c22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:10.068797Z",
-     "iopub.status.busy": "2025-07-23T16:44:10.068571Z",
-     "iopub.status.idle": "2025-07-23T16:44:11.049348Z",
-     "shell.execute_reply": "2025-07-23T16:44:11.048676Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:10.068777Z"
+     "iopub.execute_input": "2025-07-30T21:09:08.677001Z",
+     "iopub.status.busy": "2025-07-30T21:09:08.676728Z",
+     "iopub.status.idle": "2025-07-30T21:09:09.772771Z",
+     "shell.execute_reply": "2025-07-30T21:09:09.772209Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:08.676974Z"
     }
    },
    "outputs": [
@@ -523,11 +523,11 @@
    "id": "e24d338e-331d-4c4a-9637-87037029cd51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:11.050207Z",
-     "iopub.status.busy": "2025-07-23T16:44:11.049918Z",
-     "iopub.status.idle": "2025-07-23T16:44:11.055249Z",
-     "shell.execute_reply": "2025-07-23T16:44:11.054434Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:11.050185Z"
+     "iopub.execute_input": "2025-07-30T21:09:09.773654Z",
+     "iopub.status.busy": "2025-07-30T21:09:09.773317Z",
+     "iopub.status.idle": "2025-07-30T21:09:09.778206Z",
+     "shell.execute_reply": "2025-07-30T21:09:09.777658Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:09.773629Z"
     }
    },
    "outputs": [
@@ -553,19 +553,19 @@
    "id": "73482c52-1cd7-4b81-bc37-19bc0bfd2da0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:44:11.056413Z",
-     "iopub.status.busy": "2025-07-23T16:44:11.056095Z",
-     "iopub.status.idle": "2025-07-23T16:44:11.071165Z",
-     "shell.execute_reply": "2025-07-23T16:44:11.070247Z",
-     "shell.execute_reply.started": "2025-07-23T16:44:11.056382Z"
+     "iopub.execute_input": "2025-07-30T21:09:09.778968Z",
+     "iopub.status.busy": "2025-07-30T21:09:09.778766Z",
+     "iopub.status.idle": "2025-07-30T21:09:09.783442Z",
+     "shell.execute_reply": "2025-07-30T21:09:09.782907Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:09.778934Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([0.76518717, 0.6188566 , 0.24764406, 0.19526216, 0.35131399,\n",
-       "       0.19815277, 0.32923835, 0.27646319, 0.52978942, 0.86908809])"
+       "array([0.76518717, 0.6188566 , 0.24764406, 0.19526216, 0.35131398,\n",
+       "       0.19815276, 0.32923835, 0.27646319, 0.52978942, 0.86908808])"
       ]
      },
      "execution_count": 16,

--- a/notebooks/04_inversion-class.ipynb
+++ b/notebooks/04_inversion-class.ipynb
@@ -14,11 +14,11 @@
    "id": "eb4145ad-9d6a-411f-aa2e-7ab211a1f737",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.319952Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.319602Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.602628Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.602029Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.319913Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.313687Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.313341Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.582241Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.581584Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.313642Z"
     }
    },
    "outputs": [],
@@ -53,11 +53,11 @@
    "id": "22f226e2-d715-49e8-b357-38e71d78bcdc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.603309Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.603088Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.610195Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.609655Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.603292Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.583007Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.582744Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.589361Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.588730Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.582989Z"
     }
    },
    "outputs": [
@@ -86,11 +86,11 @@
    "id": "0e39a2d1-d26e-4ee2-8f9f-f3b33f1ac124",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.611040Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.610815Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.625687Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.625091Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.611006Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.590128Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.589944Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.595113Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.594499Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.590111Z"
     }
    },
    "outputs": [],
@@ -107,11 +107,11 @@
    "id": "8f052ed5-3a2b-4f32-8b44-8a86ea278960",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.626496Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.626302Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.636694Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.636109Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.626478Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.596016Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.595808Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.601468Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.601018Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.595988Z"
     }
    },
    "outputs": [
@@ -152,11 +152,11 @@
    "id": "ae80cc54-96f9-4a85-ad1f-9dce5dc38870",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.637742Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.637465Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.645711Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.645076Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.637712Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.602398Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.602132Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.606382Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.605675Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.602371Z"
     }
    },
    "outputs": [],
@@ -172,11 +172,11 @@
    "id": "050b9c20-4b0a-49af-a900-1bb964588408",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.647652Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.647440Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.654081Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.653473Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.647629Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.608569Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.608337Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.611599Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.611015Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.608549Z"
     }
    },
    "outputs": [],
@@ -190,11 +190,11 @@
    "id": "b6e3ea36-dc6b-4aa1-99b8-31721937d933",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.654833Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.654621Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.670357Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.669658Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.654813Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.612676Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.612406Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.617013Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.616506Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.612650Z"
     }
    },
    "outputs": [],
@@ -228,18 +228,18 @@
    "id": "602f9863-9ff2-4015-9ee3-3777b1ab8063",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.671065Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.670863Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.700232Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.696901Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.671047Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.617688Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.617518Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.624837Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.623989Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.617671Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<inversion_ideas.inversion.InversionLog at 0x7f1696db6ba0>"
+       "<inversion_ideas.inversion.InversionLog at 0x7ff21b2bf0e0>"
       ]
      },
      "execution_count": 8,
@@ -270,11 +270,11 @@
    "id": "cf72d7ed-3565-466f-b13a-40a5d359eb9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.704927Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.703814Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.715945Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.714027Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.704848Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.625806Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.625545Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.629198Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.628393Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.625779Z"
     }
    },
    "outputs": [],
@@ -296,18 +296,18 @@
    "id": "98fb47b4-8dd2-4909-ac2e-15803336d73d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.718783Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.717560Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.954318Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.953567Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.718724Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.630621Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.629995Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.843900Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.843347Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.630591Z"
     }
    },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "115c39cf5e7947ac88a87465b20880dd",
+       "model_id": "a0c4bcac491644bfa477fbad30cdd823",
        "version_major": 2,
        "version_minor": 0
       },
@@ -331,8 +331,8 @@
     {
      "data": {
       "text/plain": [
-       "array([0.76518717, 0.6188566 , 0.24764406, 0.19526216, 0.35131399,\n",
-       "       0.19815277, 0.32923835, 0.27646319, 0.52978942, 0.86908809])"
+       "array([0.76518717, 0.6188566 , 0.24764406, 0.19526216, 0.35131398,\n",
+       "       0.19815276, 0.32923835, 0.27646319, 0.52978942, 0.86908808])"
       ]
      },
      "execution_count": 10,
@@ -350,11 +350,11 @@
    "id": "c055371c-d884-4999-b454-f3a4ecb4b7aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.955174Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.954910Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.962451Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.961693Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.955147Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.844919Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.844640Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.852863Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.852090Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.844891Z"
     }
    },
    "outputs": [
@@ -378,12 +378,12 @@
        "        0.34564177, 0.36309911, 0.33620328, 0.47822531, 0.60771574]),\n",
        " array([0.59028089, 0.51786213, 0.29004398, 0.25083342, 0.39334167,\n",
        "        0.31476285, 0.35657259, 0.32320212, 0.51018418, 0.69384024]),\n",
-       " array([0.66683529, 0.55847535, 0.26824526, 0.2196123 , 0.38385286,\n",
-       "        0.27279565, 0.34587895, 0.30612331, 0.52660725, 0.7702903 ]),\n",
-       " array([0.72609458, 0.59284048, 0.25381956, 0.20178953, 0.36740499,\n",
-       "        0.2312603 , 0.33623043, 0.28995641, 0.53109792, 0.82923847]),\n",
-       " array([0.76518717, 0.6188566 , 0.24764406, 0.19526216, 0.35131399,\n",
-       "        0.19815277, 0.32923835, 0.27646319, 0.52978942, 0.86908809])]"
+       " array([0.66683529, 0.55847534, 0.26824525, 0.21961229, 0.38385285,\n",
+       "        0.27279564, 0.34587894, 0.30612331, 0.52660725, 0.77029029]),\n",
+       " array([0.72609463, 0.59284051, 0.25381959, 0.20178956, 0.36740502,\n",
+       "        0.23126034, 0.33623045, 0.28995643, 0.53109795, 0.82923847]),\n",
+       " array([0.76518717, 0.6188566 , 0.24764406, 0.19526216, 0.35131398,\n",
+       "        0.19815276, 0.32923835, 0.27646319, 0.52978942, 0.86908808])]"
       ]
      },
      "execution_count": 11,
@@ -401,11 +401,11 @@
    "id": "46ac6b85-67e4-4893-a08f-4e22b2c92f17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.963669Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.963297Z",
-     "iopub.status.idle": "2025-07-23T16:46:17.983596Z",
-     "shell.execute_reply": "2025-07-23T16:46:17.982997Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.963637Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.854137Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.853697Z",
+     "iopub.status.idle": "2025-07-30T21:09:53.877581Z",
+     "shell.execute_reply": "2025-07-30T21:09:53.876919Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.854105Z"
     }
    },
    "outputs": [
@@ -464,11 +464,11 @@
    "id": "274bff9a-c33c-432d-81a2-8e2bf76d7c4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:17.984748Z",
-     "iopub.status.busy": "2025-07-23T16:46:17.984393Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.223190Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.222386Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:17.984719Z"
+     "iopub.execute_input": "2025-07-30T21:09:53.878435Z",
+     "iopub.status.busy": "2025-07-30T21:09:53.878173Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.212098Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.211316Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:53.878409Z"
     }
    },
    "outputs": [
@@ -617,9 +617,9 @@
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>39.062500</td>\n",
-       "      <td>7.190663</td>\n",
+       "      <td>7.190664</td>\n",
        "      <td>2.182516</td>\n",
-       "      <td>85.254518</td>\n",
+       "      <td>85.254516</td>\n",
        "      <td>92.445180</td>\n",
        "      <td>0.287627</td>\n",
        "      <td>0.1</td>\n",
@@ -628,18 +628,18 @@
        "    <tr>\n",
        "      <th>10</th>\n",
        "      <td>19.531250</td>\n",
-       "      <td>2.710941</td>\n",
-       "      <td>2.339111</td>\n",
-       "      <td>45.685769</td>\n",
+       "      <td>2.710936</td>\n",
+       "      <td>2.339112</td>\n",
+       "      <td>45.685774</td>\n",
        "      <td>48.396710</td>\n",
-       "      <td>0.108438</td>\n",
+       "      <td>0.108437</td>\n",
        "      <td>0.1</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
        "      <td>9.765625</td>\n",
-       "      <td>1.091927</td>\n",
+       "      <td>1.091928</td>\n",
        "      <td>2.451457</td>\n",
        "      <td>23.940005</td>\n",
        "      <td>25.031933</td>\n",
@@ -663,9 +663,9 @@
        "6       312.500000   102.392487  1.511980    472.493629   574.886116   \n",
        "7       156.250000    42.856648  1.772643    276.975455   319.832103   \n",
        "8        78.125000    18.088145  1.990755    155.527715   173.615859   \n",
-       "9        39.062500     7.190663  2.182516     85.254518    92.445180   \n",
-       "10       19.531250     2.710941  2.339111     45.685769    48.396710   \n",
-       "11        9.765625     1.091927  2.451457     23.940005    25.031933   \n",
+       "9        39.062500     7.190664  2.182516     85.254516    92.445180   \n",
+       "10       19.531250     2.710936  2.339112     45.685774    48.396710   \n",
+       "11        9.765625     1.091928  2.451457     23.940005    25.031933   \n",
        "\n",
        "             chi  chi_target  chi_target met?  \n",
        "iter                                           \n",
@@ -679,7 +679,7 @@
        "7       1.714266         0.1            False  \n",
        "8       0.723526         0.1            False  \n",
        "9       0.287627         0.1            False  \n",
-       "10      0.108438         0.1            False  \n",
+       "10      0.108437         0.1            False  \n",
        "11      0.043677         0.1             True  "
       ]
      },
@@ -709,11 +709,11 @@
    "id": "7bb389e1-4181-4cd6-acc1-4b0b36ad56bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.224866Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.224045Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.230013Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.229091Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.224826Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.213036Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.212748Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.217230Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.216608Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.213016Z"
     }
    },
    "outputs": [],
@@ -729,11 +729,11 @@
    "id": "a1bdac46-da4a-4e55-a1b4-b9540fd1fd05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.231281Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.230802Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.239132Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.238284Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.231250Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.218322Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.218044Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.221663Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.220951Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.218294Z"
     }
    },
    "outputs": [],
@@ -747,11 +747,11 @@
    "id": "0c3dc76c-8dc1-4a50-8a36-3393f6e64dce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.240174Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.239928Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.246427Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.245729Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.240147Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.222590Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.222339Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.226111Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.225451Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.222571Z"
     }
    },
    "outputs": [],
@@ -785,18 +785,18 @@
    "id": "d6b33222-1b28-45b5-aa46-228497d82e07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.247263Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.247004Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.254975Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.254446Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.247234Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.226875Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.226668Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.231399Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.230729Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.226853Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<inversion_ideas.directives.MultiplierCooler at 0x7f1687f0df90>]"
+       "[<inversion_ideas.directives.MultiplierCooler at 0x7ff218692490>]"
       ]
      },
      "execution_count": 17,
@@ -814,11 +814,11 @@
    "id": "c16fb8c8-2bf3-4f3c-b66a-2f8c60051457",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.255866Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.255638Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.263797Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.263068Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.255842Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.232226Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.232042Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.237162Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.236317Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.232208Z"
     }
    },
    "outputs": [
@@ -843,11 +843,11 @@
    "id": "91434606-f407-4212-bbec-92baf481786b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.264786Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.264478Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.272053Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.271438Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.264762Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.238335Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.238023Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.243455Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.242750Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.238305Z"
     }
    },
    "outputs": [
@@ -875,11 +875,11 @@
    "id": "64cbea87-2331-4b29-b09e-aa30587713f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.273194Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.272855Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.282123Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.281247Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.273152Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.244577Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.244334Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.248792Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.248113Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.244557Z"
     }
    },
    "outputs": [
@@ -904,18 +904,18 @@
    "id": "9700abab-e6ce-46f2-9c83-655c42793090",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.286335Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.286057Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.441737Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.440933Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.286312Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.251159Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.250926Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.368221Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.367666Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.251139Z"
     }
    },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "42c7ce4fc228491f82f4070c57e7b5bb",
+       "model_id": "ddb10995cc1444028c3f034a79b536f3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -947,11 +947,11 @@
    "id": "c80aedcb-9ab3-48ba-850b-1fa031eddce1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.442998Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.442630Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.448103Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.447226Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.442963Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.369147Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.368888Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.374177Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.373310Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.369122Z"
     }
    },
    "outputs": [
@@ -964,8 +964,8 @@
       " 0.31142952 0.23900652 0.54355731 0.91770851]\n",
       "\n",
       "Inverted model:\n",
-      "[0.76518717 0.6188566  0.24764406 0.19526216 0.35131399 0.19815277\n",
-      " 0.32923835 0.27646319 0.52978942 0.86908809]\n"
+      "[0.76518717 0.6188566  0.24764406 0.19526216 0.35131398 0.19815276\n",
+      " 0.32923835 0.27646319 0.52978942 0.86908808]\n"
      ]
     }
    ],
@@ -982,11 +982,11 @@
    "id": "56a2338c-6f39-44c2-9d1e-7ee5b70f9893",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.449293Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.448984Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.458319Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.457515Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.449264Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.375539Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.375134Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.379697Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.379099Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.375508Z"
     }
    },
    "outputs": [
@@ -1011,11 +1011,11 @@
    "id": "dd0f38c3-d515-4669-9262-7fd8c7533242",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.459844Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.459325Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.467217Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.466663Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.459805Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.380766Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.380498Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.385418Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.384746Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.380740Z"
     }
    },
    "outputs": [
@@ -1043,11 +1043,11 @@
    "id": "8ff0eceb-8177-430c-9c22-3126fc306a29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.467972Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.467776Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.476168Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.475215Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.467952Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.386456Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.386151Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.391340Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.390485Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.386436Z"
     }
    },
    "outputs": [
@@ -1072,19 +1072,19 @@
    "id": "31f70c99-6d3e-4772-8b1f-821f8faa605b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:46:18.477539Z",
-     "iopub.status.busy": "2025-07-23T16:46:18.477251Z",
-     "iopub.status.idle": "2025-07-23T16:46:18.483404Z",
-     "shell.execute_reply": "2025-07-23T16:46:18.482677Z",
-     "shell.execute_reply.started": "2025-07-23T16:46:18.477514Z"
+     "iopub.execute_input": "2025-07-30T21:09:54.392714Z",
+     "iopub.status.busy": "2025-07-30T21:09:54.392188Z",
+     "iopub.status.idle": "2025-07-30T21:09:54.398210Z",
+     "shell.execute_reply": "2025-07-30T21:09:54.397473Z",
+     "shell.execute_reply.started": "2025-07-30T21:09:54.392683Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([0.76518717, 0.6188566 , 0.24764406, 0.19526216, 0.35131399,\n",
-       "       0.19815277, 0.32923835, 0.27646319, 0.52978942, 0.86908809])"
+       "array([0.76518717, 0.6188566 , 0.24764406, 0.19526216, 0.35131398,\n",
+       "       0.19815276, 0.32923835, 0.27646319, 0.52978942, 0.86908808])"
       ]
      },
      "execution_count": 26,

--- a/notebooks/05_caching-data-misfit-values.ipynb
+++ b/notebooks/05_caching-data-misfit-values.ipynb
@@ -6,11 +6,11 @@
    "id": "0707778e-d975-46b6-b670-d461e53e5b10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.038612Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.038199Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.347358Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.346818Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.038568Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.464006Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.463244Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.728976Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.728412Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.463966Z"
     }
    },
    "outputs": [],
@@ -45,11 +45,11 @@
    "id": "179250ca-3da3-4a82-8573-7a285246147b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.348011Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.347809Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.354574Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.353961Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.347994Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.729958Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.729615Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.736897Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.736272Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.729933Z"
     }
    },
    "outputs": [
@@ -78,11 +78,11 @@
    "id": "a477ebd0-8ca7-4cd2-b17d-30c21dda08c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.355316Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.355124Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.370315Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.369705Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.355299Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.737724Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.737518Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.742113Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.741455Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.737704Z"
     }
    },
    "outputs": [],
@@ -99,11 +99,11 @@
    "id": "7cc7a7bc-804b-48ea-bdb0-ebf4fa9a8e2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.371025Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.370828Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.392570Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.391970Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.371007Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.743093Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.742833Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.748379Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.747805Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.743066Z"
     }
    },
    "outputs": [
@@ -146,11 +146,11 @@
    "id": "6ec35263-f754-4931-b577-b3d4f0fc803a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.393373Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.393130Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.404313Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.403593Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.393347Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.749322Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.749087Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.753392Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.752545Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.749296Z"
     }
    },
    "outputs": [],
@@ -166,11 +166,11 @@
    "id": "050b9c20-4b0a-49af-a900-1bb964588408",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.407055Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.406378Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.413438Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.412638Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.407020Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.755818Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.755422Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.759095Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.758479Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.755791Z"
     }
    },
    "outputs": [],
@@ -184,11 +184,11 @@
    "id": "2cf726db-4849-46c3-9fca-41b5650b88b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.414773Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.414425Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.424504Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.423862Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.414742Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.760082Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.759806Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.765359Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.764769Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.760055Z"
     }
    },
    "outputs": [
@@ -213,11 +213,11 @@
    "id": "8d201eea-294d-490f-8b76-12024acc0808",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.425626Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.425306Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.433572Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.433082Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.425605Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.766789Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.766186Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.771628Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.770914Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.766760Z"
     }
    },
    "outputs": [
@@ -242,11 +242,11 @@
    "id": "da1db943-236d-43da-b0b0-e776d21931af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.434253Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.434071Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.443627Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.442954Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.434235Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.772410Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.772148Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.777351Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.776657Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.772391Z"
     }
    },
    "outputs": [
@@ -275,11 +275,11 @@
    "id": "9032d9d4-9c23-461b-bbc8-f172afdfd9ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.444312Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.444093Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.451547Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.450924Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.444293Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.778459Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.778178Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.784074Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.783231Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.778432Z"
     }
    },
    "outputs": [
@@ -304,11 +304,11 @@
    "id": "00c6e189-9deb-4cdf-8b78-887f0d8e44b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T18:23:28.452580Z",
-     "iopub.status.busy": "2025-07-23T18:23:28.452338Z",
-     "iopub.status.idle": "2025-07-23T18:23:28.460168Z",
-     "shell.execute_reply": "2025-07-23T18:23:28.459620Z",
-     "shell.execute_reply.started": "2025-07-23T18:23:28.452560Z"
+     "iopub.execute_input": "2025-07-30T21:10:35.785096Z",
+     "iopub.status.busy": "2025-07-30T21:10:35.784799Z",
+     "iopub.status.idle": "2025-07-30T21:10:35.790796Z",
+     "shell.execute_reply": "2025-07-30T21:10:35.790260Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:35.785067Z"
     }
    },
    "outputs": [

--- a/notebooks/06_jac_as_linear_operator.ipynb
+++ b/notebooks/06_jac_as_linear_operator.ipynb
@@ -14,11 +14,11 @@
    "id": "bba9bf32-da93-4100-9ee1-0983a1450bb4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.338510Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.338062Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.636430Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.635890Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.338477Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.598818Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.598592Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.896099Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.895395Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.598797Z"
     }
    },
    "outputs": [],
@@ -35,11 +35,11 @@
    "id": "afa3d214-09d3-4a0f-a402-5793d8b308b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.637149Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.636917Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.643932Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.643323Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.637130Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.897141Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.896861Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.905077Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.904363Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.897118Z"
     }
    },
    "outputs": [
@@ -68,11 +68,11 @@
    "id": "5485a55c-9727-4260-b590-1ea243dba484",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.644826Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.644641Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.648653Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.647806Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.644808Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.906121Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.905853Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.910470Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.909688Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.906099Z"
     }
    },
    "outputs": [],
@@ -89,11 +89,11 @@
    "id": "66458a9c-5e01-4a75-8fd0-fd149f447992",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.649884Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.649561Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.655301Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.654908Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.649856Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.911579Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.911309Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.917749Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.917037Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.911558Z"
     }
    },
    "outputs": [
@@ -142,11 +142,11 @@
    "id": "ad91f721-72a9-485b-9043-d85a2a220b7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.655974Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.655798Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.659130Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.658594Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.655956Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.918908Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.918622Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.922533Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.921791Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.918879Z"
     }
    },
    "outputs": [],
@@ -168,11 +168,11 @@
    "id": "a2fe9340-54a2-4699-8c64-53d5058fa17d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.661379Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.661059Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.664241Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.663469Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.661362Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.925041Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.924711Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.928506Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.927665Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.925019Z"
     }
    },
    "outputs": [],
@@ -194,11 +194,11 @@
    "id": "e8b449df-b36e-4489-bbad-8cdbecd4af2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.665368Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.665059Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.676017Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.675384Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.665339Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.929466Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.929247Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.940690Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.939938Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.929446Z"
     },
     "scrolled": true
    },
@@ -306,11 +306,11 @@
    "id": "04636169-320a-4f1e-ab42-1b083b0111dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.677331Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.676752Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.680507Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.679882Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.677302Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.941709Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.941451Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.945536Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.944922Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.941685Z"
     }
    },
    "outputs": [],
@@ -333,11 +333,11 @@
    "id": "7209972c-0045-4898-86ed-e8a7e8942159",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.681383Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.681139Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.687083Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.686299Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.681362Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.946444Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.946234Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.951719Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.950975Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.946424Z"
     }
    },
    "outputs": [
@@ -363,7 +363,7 @@
    "id": "20f8b896-9e12-4d54-b561-7e3f57f06351",
    "metadata": {},
    "source": [
-    "The hessian in this case should be a dense matrix"
+    "The hessian is a linear operator because the data misfit has `build_hessian=False`"
    ]
   },
   {
@@ -372,11 +372,11 @@
    "id": "97c0c155-83c6-44df-9c08-59ea37796f49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.688389Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.688076Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.692926Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.692164Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.688368Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.953165Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.952759Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.959087Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.958034Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.953133Z"
     },
     "scrolled": true
    },
@@ -418,11 +418,11 @@
    "id": "8da79647-eb17-4177-afb9-776f3cc4ffc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.693995Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.693701Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.699543Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.698648Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.693967Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.960705Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.960050Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.966441Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.965750Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.960666Z"
     }
    },
    "outputs": [
@@ -468,11 +468,11 @@
    "id": "539be41d-3b9f-47fb-bab1-d070b5321b23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.700743Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.700520Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.705781Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.704996Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.700724Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.967536Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.967237Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.974060Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.973249Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.967506Z"
     },
     "scrolled": true
    },
@@ -514,11 +514,11 @@
    "id": "37a7dba0-54c2-4e99-8fa6-7b641ef24117",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.706871Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.706608Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.710231Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.709467Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.706843Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.975100Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.974814Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.978658Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.977994Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.975070Z"
     }
    },
    "outputs": [],
@@ -540,11 +540,11 @@
    "id": "a498913b-88ad-4d65-b1bb-5544d4adff1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.711431Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.710997Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.716054Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.715157Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.711400Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.979521Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.979302Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.983987Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.983240Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.979500Z"
     },
     "scrolled": true
    },
@@ -570,11 +570,11 @@
    "id": "d9939f63-73e8-4d4d-b612-e7705b0a0d80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.717250Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.716940Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.721234Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.720451Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.717221Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.985046Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.984745Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.989516Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.988456Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.985016Z"
     }
    },
    "outputs": [],
@@ -596,11 +596,11 @@
    "id": "32293774-f679-4591-a305-204be136b695",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.722324Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.722014Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.726204Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.725560Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.722302Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.990939Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.990589Z",
+     "iopub.status.idle": "2025-07-30T21:10:51.995161Z",
+     "shell.execute_reply": "2025-07-30T21:10:51.994309Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.990907Z"
     }
    },
    "outputs": [],
@@ -623,11 +623,11 @@
    "id": "fc98c2da-2196-4aaa-8885-f11a8c839d32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.727004Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.726811Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.731710Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.730961Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.726986Z"
+     "iopub.execute_input": "2025-07-30T21:10:51.996281Z",
+     "iopub.status.busy": "2025-07-30T21:10:51.995994Z",
+     "iopub.status.idle": "2025-07-30T21:10:52.001820Z",
+     "shell.execute_reply": "2025-07-30T21:10:52.001056Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:51.996250Z"
     }
    },
    "outputs": [
@@ -653,7 +653,7 @@
    "id": "c9191c3e-2c0f-4d29-abf5-a20db2d64a4c",
    "metadata": {},
    "source": [
-    "The hessian in this case should be a linear operator"
+    "The hessian here is still a linear operator, both because `build_hessian=False` and because the jacobian is now a linear operator as well."
    ]
   },
   {
@@ -662,11 +662,11 @@
    "id": "b2c95d58-fdc8-4cc9-b5f3-ddb86276d5f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.733147Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.732740Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.738953Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.738099Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.733117Z"
+     "iopub.execute_input": "2025-07-30T21:10:52.002968Z",
+     "iopub.status.busy": "2025-07-30T21:10:52.002643Z",
+     "iopub.status.idle": "2025-07-30T21:10:52.008372Z",
+     "shell.execute_reply": "2025-07-30T21:10:52.007487Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:52.002938Z"
     },
     "scrolled": true
    },
@@ -708,11 +708,11 @@
    "id": "8c26274f-6907-4f7b-9378-dc9af36313d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.740214Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.739864Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.744935Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.744295Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.740182Z"
+     "iopub.execute_input": "2025-07-30T21:10:52.009233Z",
+     "iopub.status.busy": "2025-07-30T21:10:52.009012Z",
+     "iopub.status.idle": "2025-07-30T21:10:52.013761Z",
+     "shell.execute_reply": "2025-07-30T21:10:52.013159Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:52.009212Z"
     }
    },
    "outputs": [
@@ -758,11 +758,11 @@
    "id": "4805f3ac-d185-4331-8eb9-92e860e4eb0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T20:30:47.746389Z",
-     "iopub.status.busy": "2025-07-30T20:30:47.745769Z",
-     "iopub.status.idle": "2025-07-30T20:30:47.751999Z",
-     "shell.execute_reply": "2025-07-30T20:30:47.751294Z",
-     "shell.execute_reply.started": "2025-07-30T20:30:47.746358Z"
+     "iopub.execute_input": "2025-07-30T21:10:52.014817Z",
+     "iopub.status.busy": "2025-07-30T21:10:52.014552Z",
+     "iopub.status.idle": "2025-07-30T21:10:52.020544Z",
+     "shell.execute_reply": "2025-07-30T21:10:52.019696Z",
+     "shell.execute_reply.started": "2025-07-30T21:10:52.014789Z"
     },
     "scrolled": true
    },

--- a/notebooks/06_jac_as_linear_operator.ipynb
+++ b/notebooks/06_jac_as_linear_operator.ipynb
@@ -1,0 +1,881 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0ed66bfb-683e-4b0a-a4ec-50050f295070",
+   "metadata": {},
+   "source": [
+    "# Use inversion framework to fit a linear regressor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bba9bf32-da93-4100-9ee1-0983a1450bb4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T00:28:49.191250Z",
+     "iopub.status.busy": "2025-07-30T00:28:49.190826Z",
+     "iopub.status.idle": "2025-07-30T00:28:49.472378Z",
+     "shell.execute_reply": "2025-07-30T00:28:49.471742Z",
+     "shell.execute_reply.started": "2025-07-30T00:28:49.191208Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from inversion_ideas import DataMisfit, TikhonovZero, ConjugateGradient\n",
+    "from regressor import LinearRegressor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "afa3d214-09d3-4a0f-a402-5793d8b308b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T00:28:49.473247Z",
+     "iopub.status.busy": "2025-07-30T00:28:49.472990Z",
+     "iopub.status.idle": "2025-07-30T00:28:49.480019Z",
+     "shell.execute_reply": "2025-07-30T00:28:49.479310Z",
+     "shell.execute_reply.started": "2025-07-30T00:28:49.473227Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.78225148, 0.67148671, 0.2373809 , 0.17946133, 0.34662367,\n",
+       "       0.15210999, 0.31142952, 0.23900652, 0.54355731, 0.91770851])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n_params = 10\n",
+    "rng = np.random.default_rng(seed=4242)\n",
+    "true_model = rng.uniform(size=10)\n",
+    "true_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5485a55c-9727-4260-b590-1ea243dba484",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T00:28:49.481061Z",
+     "iopub.status.busy": "2025-07-30T00:28:49.480832Z",
+     "iopub.status.idle": "2025-07-30T00:28:49.488257Z",
+     "shell.execute_reply": "2025-07-30T00:28:49.487628Z",
+     "shell.execute_reply.started": "2025-07-30T00:28:49.481039Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Build the X array\n",
+    "n_data = 25\n",
+    "shape = (n_data, n_params)\n",
+    "X = rng.uniform(size=n_data * n_params).reshape(shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "66458a9c-5e01-4a75-8fd0-fd149f447992",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T00:28:49.489028Z",
+     "iopub.status.busy": "2025-07-30T00:28:49.488839Z",
+     "iopub.status.idle": "2025-07-30T00:28:49.499264Z",
+     "shell.execute_reply": "2025-07-30T00:28:49.498660Z",
+     "shell.execute_reply.started": "2025-07-30T00:28:49.489010Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([2.83840696, 2.18091081, 2.00623242, 2.08333039, 2.01694883,\n",
+       "       2.7826232 , 2.10564027, 1.27333506, 2.08859855, 1.94177648,\n",
+       "       1.88492037, 2.92394733, 2.17231952, 3.08009275, 1.61670886,\n",
+       "       1.77403753, 2.67305005, 1.91413882, 2.42117827, 2.13991628,\n",
+       "       2.0153805 , 2.71388471, 2.65944255, 2.44416121, 3.14217523])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "synthetic_data = X @ true_model\n",
+    "maxabs = np.max(np.abs(synthetic_data))\n",
+    "noise = rng.normal(scale=1e-2 * maxabs, size=synthetic_data.size)\n",
+    "synthetic_data += noise\n",
+    "synthetic_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ad91f721-72a9-485b-9043-d85a2a220b7b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T00:28:49.500151Z",
+     "iopub.status.busy": "2025-07-30T00:28:49.499919Z",
+     "iopub.status.idle": "2025-07-30T00:28:49.512776Z",
+     "shell.execute_reply": "2025-07-30T00:28:49.510270Z",
+     "shell.execute_reply.started": "2025-07-30T00:28:49.500132Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "simulation = LinearRegressor(X, linop=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "04636169-320a-4f1e-ab42-1b083b0111dd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T00:28:49.522562Z",
+     "iopub.status.busy": "2025-07-30T00:28:49.521718Z",
+     "iopub.status.idle": "2025-07-30T00:28:49.534307Z",
+     "shell.execute_reply": "2025-07-30T00:28:49.531417Z",
+     "shell.execute_reply.started": "2025-07-30T00:28:49.522486Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "uncertainty = 1e-2 * maxabs * np.ones_like(synthetic_data)\n",
+    "data_misfit = DataMisfit(synthetic_data, uncertainty, simulation)\n",
+    "smallness = TikhonovZero(n_params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8da79647-eb17-4177-afb9-776f3cc4ffc5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T00:28:49.537932Z",
+     "iopub.status.busy": "2025-07-30T00:28:49.536791Z",
+     "iopub.status.idle": "2025-07-30T00:28:49.551919Z",
+     "shell.execute_reply": "2025-07-30T00:28:49.550257Z",
+     "shell.execute_reply.started": "2025-07-30T00:28:49.537809Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\phi (m)$ + $1.00 \\cdot 10^{-3} \\, \\phi (m)$"
+      ],
+      "text/plain": [
+       "φ(m) + 0.00 φ(m)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "phi = data_misfit + 1e-3 * smallness\n",
+    "phi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d7bb890a-2958-4ea4-aa64-413f57c7b63e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T00:28:49.554157Z",
+     "iopub.status.busy": "2025-07-30T00:28:49.553464Z",
+     "iopub.status.idle": "2025-07-30T00:28:49.561318Z",
+     "shell.execute_reply": "2025-07-30T00:28:49.560365Z",
+     "shell.execute_reply.started": "2025-07-30T00:28:49.554117Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "initial_model = np.zeros(n_params)\n",
+    "initial_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7209972c-0045-4898-86ed-e8a7e8942159",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T00:28:49.562848Z",
+     "iopub.status.busy": "2025-07-30T00:28:49.562431Z",
+     "iopub.status.idle": "2025-07-30T00:28:49.571315Z",
+     "shell.execute_reply": "2025-07-30T00:28:49.570342Z",
+     "shell.execute_reply.started": "2025-07-30T00:28:49.562804Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-1733.20339929, -1985.63733369, -1773.1392767 , -1893.3319921 ,\n",
+       "       -1833.76284242, -2004.63209987, -1925.27758201, -1860.45846232,\n",
+       "       -1979.35251292, -2199.64143712])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_misfit.gradient(initial_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "97c0c155-83c6-44df-9c08-59ea37796f49",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T00:29:03.378180Z",
+     "iopub.status.busy": "2025-07-30T00:29:03.377237Z",
+     "iopub.status.idle": "2025-07-30T00:29:03.912509Z",
+     "shell.execute_reply": "2025-07-30T00:29:03.911110Z",
+     "shell.execute_reply.started": "2025-07-30T00:29:03.378148Z"
+    }
+   },
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Unable to multiply a LinearOperator with a sparse matrix. Wrap the matrix in aslinearoperator first.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:366\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    365\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m366\u001b[39m     Y = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_matmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    367\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:613\u001b[39m, in \u001b[36m_CustomLinearOperator._matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    612\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m613\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_matmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:213\u001b[39m, in \u001b[36mLinearOperator._matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    207\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"Default matrix-matrix multiplication handler.\u001b[39;00m\n\u001b[32m    208\u001b[39m \n\u001b[32m    209\u001b[39m \u001b[33;03mFalls back on the user-defined _matvec method, so defining that will\u001b[39;00m\n\u001b[32m    210\u001b[39m \u001b[33;03mdefine matrix multiplication (though in a very suboptimal way).\u001b[39;00m\n\u001b[32m    211\u001b[39m \u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m213\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m np.hstack(\u001b[43m[\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mmatvec\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcol\u001b[49m\u001b[43m.\u001b[49m\u001b[43mreshape\u001b[49m\u001b[43m(\u001b[49m\u001b[43m-\u001b[49m\u001b[32;43m1\u001b[39;49m\u001b[43m,\u001b[49m\u001b[32;43m1\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mcol\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mX\u001b[49m\u001b[43m.\u001b[49m\u001b[43mT\u001b[49m\u001b[43m]\u001b[49m)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/_base.py:286\u001b[39m, in \u001b[36m_spbase.__iter__\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    285\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m r \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mrange\u001b[39m(\u001b[38;5;28mself\u001b[39m.shape[\u001b[32m0\u001b[39m]):\n\u001b[32m--> \u001b[39m\u001b[32m286\u001b[39m     \u001b[38;5;28;01myield\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m[\u001b[49m\u001b[43mr\u001b[49m\u001b[43m]\u001b[49m\n",
+      "\u001b[31mTypeError\u001b[39m: 'dia_array' object is not subscriptable",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:366\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    365\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m366\u001b[39m     Y = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_matmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    367\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:678\u001b[39m, in \u001b[36m_TransposedLinearOperator._matmat\u001b[39m\u001b[34m(self, x)\u001b[39m\n\u001b[32m    676\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_matmat\u001b[39m(\u001b[38;5;28mself\u001b[39m, x):\n\u001b[32m    677\u001b[39m     \u001b[38;5;66;03m# NB. np.conj works also on sparse matrices\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m678\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m np.conj(\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mA\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_rmatmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnp\u001b[49m\u001b[43m.\u001b[49m\u001b[43mconj\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:628\u001b[39m, in \u001b[36m_CustomLinearOperator._rmatmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    627\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m628\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_rmatmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:430\u001b[39m, in \u001b[36mLinearOperator._rmatmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    429\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m430\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mH\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmatmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:369\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    368\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m issparse(X) \u001b[38;5;129;01mor\u001b[39;00m is_pydata_spmatrix(X):\n\u001b[32m--> \u001b[39m\u001b[32m369\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\n\u001b[32m    370\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mUnable to multiply a LinearOperator with a sparse matrix.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    371\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m Wrap the matrix in aslinearoperator first.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    372\u001b[39m     ) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01me\u001b[39;00m\n\u001b[32m    373\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m\n",
+      "\u001b[31mTypeError\u001b[39m: Unable to multiply a LinearOperator with a sparse matrix. Wrap the matrix in aslinearoperator first.",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:366\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    365\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m366\u001b[39m     Y = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_matmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    367\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:774\u001b[39m, in \u001b[36m_ScaledLinearOperator._matmat\u001b[39m\u001b[34m(self, x)\u001b[39m\n\u001b[32m    773\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_matmat\u001b[39m(\u001b[38;5;28mself\u001b[39m, x):\n\u001b[32m--> \u001b[39m\u001b[32m774\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m.args[\u001b[32m1\u001b[39m] * \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43margs\u001b[49m\u001b[43m[\u001b[49m\u001b[32;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmatmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:369\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    368\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m issparse(X) \u001b[38;5;129;01mor\u001b[39;00m is_pydata_spmatrix(X):\n\u001b[32m--> \u001b[39m\u001b[32m369\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\n\u001b[32m    370\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mUnable to multiply a LinearOperator with a sparse matrix.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    371\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m Wrap the matrix in aslinearoperator first.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    372\u001b[39m     ) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01me\u001b[39;00m\n\u001b[32m    373\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m\n",
+      "\u001b[31mTypeError\u001b[39m: Unable to multiply a LinearOperator with a sparse matrix. Wrap the matrix in aslinearoperator first.",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[10]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mdata_misfit\u001b[49m\u001b[43m.\u001b[49m\u001b[43mhessian\u001b[49m\u001b[43m(\u001b[49m\u001b[43minitial_model\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/git/inversion-design-ideas/src/inversion_ideas/data_misfit.py:52\u001b[39m, in \u001b[36mDataMisfit.hessian\u001b[39m\u001b[34m(self, model)\u001b[39m\n\u001b[32m     48\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m     49\u001b[39m \u001b[33;03mHessian matrix.\u001b[39;00m\n\u001b[32m     50\u001b[39m \u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m     51\u001b[39m jac = \u001b[38;5;28mself\u001b[39m.simulation.jacobian(model)\n\u001b[32m---> \u001b[39m\u001b[32m52\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[32;43m2\u001b[39;49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m \u001b[49m\u001b[43mjac\u001b[49m\u001b[43m.\u001b[49m\u001b[43mT\u001b[49m\u001b[43m \u001b[49m\u001b[43m@\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mweights_squared\u001b[49m @ jac\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:479\u001b[39m, in \u001b[36mLinearOperator.__matmul__\u001b[39m\u001b[34m(self, other)\u001b[39m\n\u001b[32m    476\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m np.isscalar(other):\n\u001b[32m    477\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33m\"\u001b[39m\u001b[33mScalar operands are not allowed, \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    478\u001b[39m                      \u001b[33m\"\u001b[39m\u001b[33muse \u001b[39m\u001b[33m'\u001b[39m\u001b[33m*\u001b[39m\u001b[33m'\u001b[39m\u001b[33m instead\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m--> \u001b[39m\u001b[32m479\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[34;43m__mul__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mother\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:436\u001b[39m, in \u001b[36mLinearOperator.__mul__\u001b[39m\u001b[34m(self, x)\u001b[39m\n\u001b[32m    435\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m__mul__\u001b[39m(\u001b[38;5;28mself\u001b[39m, x):\n\u001b[32m--> \u001b[39m\u001b[32m436\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mdot\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:471\u001b[39m, in \u001b[36mLinearOperator.dot\u001b[39m\u001b[34m(self, x)\u001b[39m\n\u001b[32m    469\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m.matvec(x)\n\u001b[32m    470\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m x.ndim == \u001b[32m2\u001b[39m:\n\u001b[32m--> \u001b[39m\u001b[32m471\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mmatmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    472\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    473\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m'\u001b[39m\u001b[33mexpected 1-d or 2-d array or matrix, got \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mx\u001b[38;5;132;01m!r}\u001b[39;00m\u001b[33m'\u001b[39m)\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:369\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    367\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m    368\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m issparse(X) \u001b[38;5;129;01mor\u001b[39;00m is_pydata_spmatrix(X):\n\u001b[32m--> \u001b[39m\u001b[32m369\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\n\u001b[32m    370\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33mUnable to multiply a LinearOperator with a sparse matrix.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    371\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33m Wrap the matrix in aslinearoperator first.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    372\u001b[39m         ) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01me\u001b[39;00m\n\u001b[32m    373\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m\n\u001b[32m    375\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(Y, np.matrix):\n",
+      "\u001b[31mTypeError\u001b[39m: Unable to multiply a LinearOperator with a sparse matrix. Wrap the matrix in aslinearoperator first."
+     ]
+    }
+   ],
+   "source": [
+    "data_misfit.hessian(initial_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cc54476-cd31-4bf6-bc0f-bfd6254af7ec",
+   "metadata": {},
+   "source": [
+    "## Minimize manually with `scipy.sparse.linalg.cg`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d4bac3a2-49d5-4592-a793-72789ec31a5c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.564296Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.564102Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.570018Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.569178Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.564276Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from scipy.sparse.linalg import cg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c3369162-abe9-4fb9-9294-69277e50ef13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.571299Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.570942Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.580311Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.579716Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.571263Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "grad = phi.gradient(initial_model)\n",
+    "hess = phi.hessian(initial_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c1fed88c-9c34-4ee3-8208-e7b50c2ec678",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.581353Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.581065Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.590994Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.590280Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.581322Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([0.81328361, 0.65926983, 0.24729306, 0.19624665, 0.32373823,\n",
+       "        0.14720994, 0.31944798, 0.25236328, 0.52215617, 0.92180399]),\n",
+       " 0)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_step, info = cg(hess, -grad)\n",
+    "model_step, info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "54a8ef70-6e5f-4000-ad2f-658dbffd83f1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.592437Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.591894Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.598507Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.597755Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.592402Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "inverted_model = initial_model + model_step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b05f913f-dcfa-4bca-a277-b9cf5c9de6b5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.599803Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.599475Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.607380Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.606608Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.599770Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result:\n",
+      "[0.81328361 0.65926983 0.24729306 0.19624665 0.32373823 0.14720994\n",
+      " 0.31944798 0.25236328 0.52215617 0.92180399]\n",
+      "\n",
+      "True model:\n",
+      "[0.78225148 0.67148671 0.2373809  0.17946133 0.34662367 0.15210999\n",
+      " 0.31142952 0.23900652 0.54355731 0.91770851]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Result:\")\n",
+    "print(inverted_model)\n",
+    "print()\n",
+    "print(\"True model:\")\n",
+    "print(true_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad0f7d22-77d6-410c-bca1-e3d765006aff",
+   "metadata": {},
+   "source": [
+    "## Minimize with SciPy's `minimize`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5f36ec3b-0380-4eeb-b01a-3191c12b70f5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.608344Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.608101Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.720380Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.719607Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.608321Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from scipy.optimize import minimize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ba337ea8-0afb-46aa-b107-07bcf86a8324",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.721392Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.721124Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.840698Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.839910Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.721368Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "  message: Optimization terminated successfully.\n",
+       "  success: True\n",
+       "   status: 0\n",
+       "      fun: 0.37159603111570305\n",
+       "        x: [ 8.133e-01  6.592e-01  2.473e-01  1.963e-01  3.237e-01\n",
+       "             1.472e-01  3.195e-01  2.524e-01  5.222e-01  9.218e-01]\n",
+       "      nit: 16\n",
+       "      jac: [-1.378e-07  2.645e-07  1.155e-07  1.118e-08 -1.006e-07\n",
+       "             1.714e-07 -3.725e-08  2.682e-07  3.353e-08  1.602e-07]\n",
+       " hess_inv: [[ 1.077e-02 -3.331e-03 ...  5.039e-04 -2.987e-03]\n",
+       "            [-3.331e-03  1.286e-02 ... -3.213e-03 -4.085e-04]\n",
+       "            ...\n",
+       "            [ 5.039e-04 -3.213e-03 ...  6.867e-03 -1.745e-03]\n",
+       "            [-2.987e-03 -4.085e-04 ... -1.745e-03  8.357e-03]]\n",
+       "     nfev: 231\n",
+       "     njev: 21"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result =  minimize(phi, initial_model)\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "d5cf83b5-6cbd-42d1-9513-d3ca38464b72",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.841743Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.841366Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.845304Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.844651Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.841708Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The minimize already gives you the minimum model\n",
+    "inverted_model = result.x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "d25be88b-3134-447a-b003-c80dddff3166",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.846649Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.845928Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.855068Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.854320Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.846613Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result:\n",
+      "[0.81325615 0.65924881 0.24726449 0.19626688 0.32373389 0.14719947\n",
+      " 0.31947497 0.25235411 0.5221697  0.92183533]\n",
+      "\n",
+      "True model:\n",
+      "[0.78225148 0.67148671 0.2373809  0.17946133 0.34662367 0.15210999\n",
+      " 0.31142952 0.23900652 0.54355731 0.91770851]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Result:\")\n",
+    "print(inverted_model)\n",
+    "print()\n",
+    "print(\"True model:\")\n",
+    "print(true_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "50cb98a1-1fc8-4378-a517-09ed910ce1c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.856190Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.855868Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.891088Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.890143Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.856166Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       " message: Optimization terminated successfully.\n",
+       " success: True\n",
+       "  status: 0\n",
+       "     fun: 0.3715960311156836\n",
+       "       x: [ 8.133e-01  6.592e-01  2.473e-01  1.963e-01  3.237e-01\n",
+       "            1.472e-01  3.195e-01  2.524e-01  5.222e-01  9.218e-01]\n",
+       "     nit: 12\n",
+       "     jac: [ 3.612e-12  7.223e-12  7.137e-12  4.872e-12  5.592e-12\n",
+       "            6.519e-12  6.291e-12  7.993e-12  6.342e-12  8.719e-12]\n",
+       "    nfev: 24\n",
+       "    njev: 24"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result =  minimize(phi, initial_model, jac=phi.gradient, method=\"CG\")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "45a7c13a-79ea-445f-b63d-b551787ebc20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.892479Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.892090Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.895990Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.895283Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.892440Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The minimize already gives you the minimum model\n",
+    "inverted_model = result.x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "094fbf19-b676-4aba-8e23-b93abb8b2431",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.897061Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.896763Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.906265Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.905380Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.897031Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result:\n",
+      "[0.81325615 0.65924881 0.2472645  0.19626689 0.32373389 0.14719947\n",
+      " 0.31947497 0.25235411 0.5221697  0.92183533]\n",
+      "\n",
+      "True model:\n",
+      "[0.78225148 0.67148671 0.2373809  0.17946133 0.34662367 0.15210999\n",
+      " 0.31142952 0.23900652 0.54355731 0.91770851]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Result:\")\n",
+    "print(result.x)\n",
+    "print()\n",
+    "print(\"True model:\")\n",
+    "print(true_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "65235b83-fd51-4f52-b7ba-3c0dc2a35fe2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.909944Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.909618Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.951403Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.950711Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.909917Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       " message: Optimization terminated successfully.\n",
+       " success: True\n",
+       "  status: 0\n",
+       "     fun: 0.3715960311172809\n",
+       "       x: [ 8.133e-01  6.592e-01  2.473e-01  1.963e-01  3.237e-01\n",
+       "            1.472e-01  3.195e-01  2.524e-01  5.222e-01  9.218e-01]\n",
+       "     nit: 10\n",
+       "     jac: [-1.755e-04 -1.486e-04  1.521e-04  4.685e-05  3.222e-05\n",
+       "           -1.612e-04  8.816e-05  7.859e-06  3.653e-04 -1.935e-04]\n",
+       "    nfev: 11\n",
+       "    njev: 11\n",
+       "    nhev: 10"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result =  minimize(phi, initial_model, jac=phi.gradient, hess=phi.hessian, method=\"Newton-CG\")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "45df89b6-58fc-472c-bfa6-96f1d3c7cc5c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.952542Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.952189Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.956340Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.955516Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.952505Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The minimize already gives you the minimum model\n",
+    "inverted_model = result.x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "2e9d2ee1-bfd9-4c3d-9865-f63d08a25b07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.957539Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.957156Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.966604Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.965778Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.957497Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result:\n",
+      "[0.81325626 0.65924868 0.24726445 0.19626684 0.32373384 0.14719954\n",
+      " 0.31947496 0.25235426 0.52216973 0.92183526]\n",
+      "\n",
+      "True model:\n",
+      "[0.78225148 0.67148671 0.2373809  0.17946133 0.34662367 0.15210999\n",
+      " 0.31142952 0.23900652 0.54355731 0.91770851]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Result:\")\n",
+    "print(result.x)\n",
+    "print()\n",
+    "print(\"True model:\")\n",
+    "print(true_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ded8a6fd-c419-4b13-bf3e-9d221c78a368",
+   "metadata": {},
+   "source": [
+    "## Use `Minimizer` class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "34372a3f-ff42-435f-9423-a4f99712fd9c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.967786Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.967434Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.975769Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.974822Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.967749Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<inversion_ideas.minimizer.ConjugateGradient at 0x7fd33143a7b0>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minimizer = ConjugateGradient()\n",
+    "minimizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "f3f52071-c2c5-4016-9d61-cd2f3b781698",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.977062Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.976761Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.983704Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.983111Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.977038Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "inverted_model = minimizer(phi, initial_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "e41d3e15-1a74-42b9-9583-cacb8aeceadc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-23T16:35:11.984622Z",
+     "iopub.status.busy": "2025-07-23T16:35:11.984347Z",
+     "iopub.status.idle": "2025-07-23T16:35:11.992186Z",
+     "shell.execute_reply": "2025-07-23T16:35:11.991340Z",
+     "shell.execute_reply.started": "2025-07-23T16:35:11.984589Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result:\n",
+      "[0.81328361 0.65926983 0.24729306 0.19624665 0.32373823 0.14720994\n",
+      " 0.31944798 0.25236328 0.52215617 0.92180399]\n",
+      "\n",
+      "True model:\n",
+      "[0.78225148 0.67148671 0.2373809  0.17946133 0.34662367 0.15210999\n",
+      " 0.31142952 0.23900652 0.54355731 0.91770851]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Result:\")\n",
+    "print(inverted_model)\n",
+    "print()\n",
+    "print(\"True model:\")\n",
+    "print(true_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a35232d-899c-4746-884d-58cb6b60a52d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:inversion_ideas]",
+   "language": "python",
+   "name": "conda-env-inversion_ideas-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/06_jac_as_linear_operator.ipynb
+++ b/notebooks/06_jac_as_linear_operator.ipynb
@@ -5,7 +5,7 @@
    "id": "0ed66bfb-683e-4b0a-a4ec-50050f295070",
    "metadata": {},
    "source": [
-    "# Use inversion framework to fit a linear regressor"
+    "# Experiment with jacobian as a linear operator"
    ]
   },
   {
@@ -14,11 +14,11 @@
    "id": "bba9bf32-da93-4100-9ee1-0983a1450bb4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T00:28:49.191250Z",
-     "iopub.status.busy": "2025-07-30T00:28:49.190826Z",
-     "iopub.status.idle": "2025-07-30T00:28:49.472378Z",
-     "shell.execute_reply": "2025-07-30T00:28:49.471742Z",
-     "shell.execute_reply.started": "2025-07-30T00:28:49.191208Z"
+     "iopub.execute_input": "2025-07-30T20:30:47.338510Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.338062Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.636430Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.635890Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.338477Z"
     }
    },
    "outputs": [],
@@ -35,11 +35,11 @@
    "id": "afa3d214-09d3-4a0f-a402-5793d8b308b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T00:28:49.473247Z",
-     "iopub.status.busy": "2025-07-30T00:28:49.472990Z",
-     "iopub.status.idle": "2025-07-30T00:28:49.480019Z",
-     "shell.execute_reply": "2025-07-30T00:28:49.479310Z",
-     "shell.execute_reply.started": "2025-07-30T00:28:49.473227Z"
+     "iopub.execute_input": "2025-07-30T20:30:47.637149Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.636917Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.643932Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.643323Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.637130Z"
     }
    },
    "outputs": [
@@ -68,11 +68,11 @@
    "id": "5485a55c-9727-4260-b590-1ea243dba484",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T00:28:49.481061Z",
-     "iopub.status.busy": "2025-07-30T00:28:49.480832Z",
-     "iopub.status.idle": "2025-07-30T00:28:49.488257Z",
-     "shell.execute_reply": "2025-07-30T00:28:49.487628Z",
-     "shell.execute_reply.started": "2025-07-30T00:28:49.481039Z"
+     "iopub.execute_input": "2025-07-30T20:30:47.644826Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.644641Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.648653Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.647806Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.644808Z"
     }
    },
    "outputs": [],
@@ -89,11 +89,11 @@
    "id": "66458a9c-5e01-4a75-8fd0-fd149f447992",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T00:28:49.489028Z",
-     "iopub.status.busy": "2025-07-30T00:28:49.488839Z",
-     "iopub.status.idle": "2025-07-30T00:28:49.499264Z",
-     "shell.execute_reply": "2025-07-30T00:28:49.498660Z",
-     "shell.execute_reply.started": "2025-07-30T00:28:49.489010Z"
+     "iopub.execute_input": "2025-07-30T20:30:47.649884Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.649561Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.655301Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.654908Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.649856Z"
     }
    },
    "outputs": [
@@ -121,54 +121,308 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "45f03194-d902-4dd3-bbb9-c90604916759",
+   "metadata": {},
+   "source": [
+    "## Linear regressor with jacobian as a dense matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcd7b531-1ba4-4fd9-b319-0702466cee3d",
+   "metadata": {},
+   "source": [
+    "Define the simulation"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "ad91f721-72a9-485b-9043-d85a2a220b7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T00:28:49.500151Z",
-     "iopub.status.busy": "2025-07-30T00:28:49.499919Z",
-     "iopub.status.idle": "2025-07-30T00:28:49.512776Z",
-     "shell.execute_reply": "2025-07-30T00:28:49.510270Z",
-     "shell.execute_reply.started": "2025-07-30T00:28:49.500132Z"
+     "iopub.execute_input": "2025-07-30T20:30:47.655974Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.655798Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.659130Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.658594Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.655956Z"
     }
    },
    "outputs": [],
    "source": [
-    "simulation = LinearRegressor(X, linop=True)"
+    "simulation = LinearRegressor(X, linop=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7917016-f222-4440-8e40-965ff7186f3b",
+   "metadata": {},
+   "source": [
+    "And a random model"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "04636169-320a-4f1e-ab42-1b083b0111dd",
+   "id": "a2fe9340-54a2-4699-8c64-53d5058fa17d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T00:28:49.522562Z",
-     "iopub.status.busy": "2025-07-30T00:28:49.521718Z",
-     "iopub.status.idle": "2025-07-30T00:28:49.534307Z",
-     "shell.execute_reply": "2025-07-30T00:28:49.531417Z",
-     "shell.execute_reply.started": "2025-07-30T00:28:49.522486Z"
+     "iopub.execute_input": "2025-07-30T20:30:47.661379Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.661059Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.664241Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.663469Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.661362Z"
     }
    },
    "outputs": [],
    "source": [
-    "uncertainty = 1e-2 * maxabs * np.ones_like(synthetic_data)\n",
-    "data_misfit = DataMisfit(synthetic_data, uncertainty, simulation)\n",
-    "smallness = TikhonovZero(n_params)"
+    "model = np.random.default_rng(seed=404).uniform(size=simulation.n_params)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37146e2c-56f2-4e95-ab65-67281971bc98",
+   "metadata": {},
+   "source": [
+    "Evaluate the jacobian"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "e8b449df-b36e-4489-bbad-8cdbecd4af2e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:30:47.665368Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.665059Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.676017Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.675384Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.665339Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[4.44264723e-01, 7.60284086e-01, 5.75280767e-01, 5.11884120e-01,\n",
+       "        6.57160266e-01, 9.46730040e-01, 9.15303691e-01, 7.20234663e-01,\n",
+       "        1.22754477e-01, 9.09341434e-01],\n",
+       "       [7.13282058e-01, 3.53302920e-01, 2.21366873e-01, 9.14078303e-01,\n",
+       "        8.15687052e-01, 3.40313380e-01, 9.62818089e-01, 6.83787068e-01,\n",
+       "        3.63987604e-02, 3.84888353e-01],\n",
+       "       [1.42086599e-01, 3.54204403e-01, 9.67718984e-01, 5.95587095e-01,\n",
+       "        3.95789476e-01, 1.83878615e-01, 2.77425050e-01, 7.18244514e-01,\n",
+       "        9.17009668e-01, 4.22921723e-01],\n",
+       "       [1.83523965e-01, 5.00748020e-01, 8.23541669e-01, 3.63411724e-01,\n",
+       "        4.88826840e-01, 5.71664781e-01, 8.73267349e-01, 6.96450781e-01,\n",
+       "        8.27504216e-01, 2.34782839e-01],\n",
+       "       [3.60832015e-01, 7.87289140e-03, 9.92841209e-01, 1.37940229e-01,\n",
+       "        7.17729471e-01, 7.83053514e-01, 8.17056956e-01, 2.37562075e-01,\n",
+       "        2.96404717e-01, 6.44919192e-01],\n",
+       "       [2.46095918e-01, 7.12840133e-01, 2.62346116e-01, 3.63872300e-01,\n",
+       "        5.35495292e-01, 8.65386063e-01, 5.55420833e-01, 7.05003327e-01,\n",
+       "        9.29822695e-01, 9.26704829e-01],\n",
+       "       [6.53584950e-01, 2.28743082e-01, 6.07552487e-01, 7.21696075e-01,\n",
+       "        4.59714345e-01, 7.40911934e-01, 4.85402390e-01, 4.74013453e-01,\n",
+       "        1.73821094e-01, 5.59757997e-01],\n",
+       "       [8.29094668e-03, 9.66549856e-02, 4.19627481e-01, 8.48052175e-01,\n",
+       "        7.49057652e-02, 5.25384197e-01, 5.76287344e-02, 1.90674816e-01,\n",
+       "        1.94500916e-01, 7.52548335e-01],\n",
+       "       [4.25823006e-01, 7.85239618e-02, 3.54280834e-01, 3.13304206e-01,\n",
+       "        1.39183783e-01, 5.95847625e-01, 4.62795411e-01, 5.65738885e-01,\n",
+       "        3.20048733e-01, 9.97419861e-01],\n",
+       "       [3.15861489e-01, 6.94851186e-01, 7.15983076e-01, 5.26081751e-02,\n",
+       "        5.84630964e-02, 2.22229808e-01, 8.03285972e-01, 8.08414357e-01,\n",
+       "        1.91101764e-01, 4.97763356e-01],\n",
+       "       [4.84521155e-01, 5.30709888e-01, 1.47183794e-01, 9.71596211e-01,\n",
+       "        7.23422189e-02, 3.80655745e-01, 6.83623080e-01, 5.50656878e-01,\n",
+       "        3.92556771e-01, 2.83943549e-01],\n",
+       "       [4.70078920e-01, 9.02994645e-01, 7.36383892e-01, 6.49147784e-01,\n",
+       "        6.63950143e-01, 7.21341333e-01, 3.03542768e-01, 7.90822311e-01,\n",
+       "        6.32093870e-01, 7.35808988e-01],\n",
+       "       [8.87580964e-01, 6.17369703e-01, 3.12462364e-01, 3.44485871e-01,\n",
+       "        1.27308174e-01, 9.08466300e-01, 2.17763861e-01, 5.89994763e-01,\n",
+       "        3.31906170e-01, 3.78346862e-01],\n",
+       "       [2.77943668e-01, 9.63811834e-01, 6.73101719e-02, 7.77192200e-01,\n",
+       "        4.98128689e-01, 8.09440241e-01, 6.23838790e-01, 6.59942656e-01,\n",
+       "        9.85691121e-01, 9.46579899e-01],\n",
+       "       [9.78835290e-02, 4.52498705e-01, 1.09149218e-02, 6.73052380e-01,\n",
+       "        5.31598758e-01, 1.87979151e-01, 1.83252227e-01, 9.78578505e-01,\n",
+       "        6.96230329e-01, 2.40608218e-01],\n",
+       "       [1.52583775e-01, 5.13165883e-01, 3.77264997e-01, 7.03646783e-01,\n",
+       "        3.41326670e-01, 5.53333580e-01, 6.48151553e-01, 1.60502604e-01,\n",
+       "        8.79237058e-01, 2.01484537e-01],\n",
+       "       [6.74188526e-01, 6.04251696e-01, 8.28612014e-01, 9.55512253e-01,\n",
+       "        9.92795853e-01, 6.39573769e-01, 3.60375907e-01, 6.19861075e-01,\n",
+       "        9.36883504e-01, 1.64777064e-01],\n",
+       "       [3.78935171e-01, 8.90875876e-01, 9.98947829e-03, 7.01354177e-01,\n",
+       "        3.69901384e-01, 8.46761002e-01, 3.00066721e-01, 1.79101135e-01,\n",
+       "        3.88746987e-02, 4.88744498e-01],\n",
+       "       [4.17389604e-01, 3.48857314e-01, 6.69662549e-01, 7.19781537e-01,\n",
+       "        8.59400977e-01, 9.85801959e-01, 6.95495011e-01, 2.59086730e-01,\n",
+       "        5.46313452e-01, 6.39502663e-01],\n",
+       "       [6.11070349e-01, 6.39823007e-01, 5.93429274e-01, 8.30726986e-02,\n",
+       "        5.41909593e-03, 3.36844196e-01, 8.04472862e-01, 2.83522392e-01,\n",
+       "        6.62629565e-01, 3.49625649e-01],\n",
+       "       [2.50473128e-01, 8.06200433e-01, 7.32076824e-01, 7.52012165e-01,\n",
+       "        4.26759252e-01, 8.28443520e-01, 3.73472590e-01, 8.58770065e-01,\n",
+       "        5.08914561e-02, 3.23114311e-01],\n",
+       "       [6.15926519e-01, 3.98539936e-01, 7.78905194e-01, 7.80932388e-01,\n",
+       "        6.36501154e-01, 7.32352059e-02, 9.83013960e-01, 4.11753636e-01,\n",
+       "        5.00579290e-01, 7.49054120e-01],\n",
+       "       [9.53236133e-01, 1.85570703e-01, 2.90168961e-01, 1.54007208e-01,\n",
+       "        6.57448381e-01, 1.97691171e-01, 7.06863354e-01, 5.91656616e-02,\n",
+       "        8.43325391e-01, 7.77418629e-01],\n",
+       "       [5.58823452e-01, 7.11478506e-01, 3.57516580e-01, 1.54542705e-01,\n",
+       "        3.60099971e-01, 1.60142792e-01, 6.75908527e-02, 3.46173376e-01,\n",
+       "        7.30542044e-01, 8.71176016e-01],\n",
+       "       [9.80313413e-01, 7.63708338e-01, 3.52041859e-01, 1.01513987e-01,\n",
+       "        9.50896782e-01, 2.80007942e-01, 3.72325743e-05, 2.59840660e-01,\n",
+       "        7.94573312e-01, 9.82281033e-01]])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation.jacobian(model)  # should return a dense array"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c15154b-5fc9-435c-a1c6-180f3df48eb9",
+   "metadata": {},
+   "source": [
+    "Define a data misfit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "04636169-320a-4f1e-ab42-1b083b0111dd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:30:47.677331Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.676752Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.680507Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.679882Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.677302Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "uncertainty = 1e-2 * maxabs * np.ones_like(synthetic_data)\n",
+    "data_misfit = DataMisfit(synthetic_data, uncertainty, simulation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09c93fb3-7f48-49d4-8552-1dbcf65910b4",
+   "metadata": {},
+   "source": [
+    "The gradient of the data misfit is a vector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7209972c-0045-4898-86ed-e8a7e8942159",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:30:47.681383Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.681139Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.687083Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.686299Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.681362Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-571.55938062, -574.94129596, -500.28936815, -448.79630088,\n",
+       "       -532.78827694, -533.01745238, -575.12462734, -486.11230303,\n",
+       "       -639.0398147 , -732.49096897])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_misfit.gradient(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20f8b896-9e12-4d54-b561-7e3f57f06351",
+   "metadata": {},
+   "source": [
+    "The hessian in this case should be a dense matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "97c0c155-83c6-44df-9c08-59ea37796f49",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:30:47.688389Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.688076Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.692926Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.692164Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.688368Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<10x10 _ProductLinearOperator with dtype=float64>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_misfit.hessian(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e28e435-c897-4ef9-bbcc-5319e81caff5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:22:47.527483Z",
+     "iopub.status.busy": "2025-07-30T20:22:47.526618Z",
+     "iopub.status.idle": "2025-07-30T20:22:47.540681Z",
+     "shell.execute_reply": "2025-07-30T20:22:47.538612Z",
+     "shell.execute_reply.started": "2025-07-30T20:22:47.527411Z"
+    }
+   },
+   "source": [
+    "Define an objective function with regularization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
    "id": "8da79647-eb17-4177-afb9-776f3cc4ffc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-30T00:28:49.537932Z",
-     "iopub.status.busy": "2025-07-30T00:28:49.536791Z",
-     "iopub.status.idle": "2025-07-30T00:28:49.551919Z",
-     "shell.execute_reply": "2025-07-30T00:28:49.550257Z",
-     "shell.execute_reply.started": "2025-07-30T00:28:49.537809Z"
+     "iopub.execute_input": "2025-07-30T20:30:47.693995Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.693701Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.699543Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.698648Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.693967Z"
     }
    },
    "outputs": [
@@ -181,418 +435,246 @@
        "φ(m) + 0.00 φ(m)"
       ]
      },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "phi = data_misfit + 1e-3 * smallness\n",
-    "phi"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "d7bb890a-2958-4ea4-aa64-413f57c7b63e",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-30T00:28:49.554157Z",
-     "iopub.status.busy": "2025-07-30T00:28:49.553464Z",
-     "iopub.status.idle": "2025-07-30T00:28:49.561318Z",
-     "shell.execute_reply": "2025-07-30T00:28:49.560365Z",
-     "shell.execute_reply.started": "2025-07-30T00:28:49.554117Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "initial_model = np.zeros(n_params)\n",
-    "initial_model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "7209972c-0045-4898-86ed-e8a7e8942159",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-30T00:28:49.562848Z",
-     "iopub.status.busy": "2025-07-30T00:28:49.562431Z",
-     "iopub.status.idle": "2025-07-30T00:28:49.571315Z",
-     "shell.execute_reply": "2025-07-30T00:28:49.570342Z",
-     "shell.execute_reply.started": "2025-07-30T00:28:49.562804Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([-1733.20339929, -1985.63733369, -1773.1392767 , -1893.3319921 ,\n",
-       "       -1833.76284242, -2004.63209987, -1925.27758201, -1860.45846232,\n",
-       "       -1979.35251292, -2199.64143712])"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "data_misfit.gradient(initial_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "97c0c155-83c6-44df-9c08-59ea37796f49",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-30T00:29:03.378180Z",
-     "iopub.status.busy": "2025-07-30T00:29:03.377237Z",
-     "iopub.status.idle": "2025-07-30T00:29:03.912509Z",
-     "shell.execute_reply": "2025-07-30T00:29:03.911110Z",
-     "shell.execute_reply.started": "2025-07-30T00:29:03.378148Z"
-    }
-   },
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "Unable to multiply a LinearOperator with a sparse matrix. Wrap the matrix in aslinearoperator first.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:366\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    365\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m366\u001b[39m     Y = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_matmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    367\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:613\u001b[39m, in \u001b[36m_CustomLinearOperator._matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    612\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m613\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_matmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:213\u001b[39m, in \u001b[36mLinearOperator._matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    207\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"Default matrix-matrix multiplication handler.\u001b[39;00m\n\u001b[32m    208\u001b[39m \n\u001b[32m    209\u001b[39m \u001b[33;03mFalls back on the user-defined _matvec method, so defining that will\u001b[39;00m\n\u001b[32m    210\u001b[39m \u001b[33;03mdefine matrix multiplication (though in a very suboptimal way).\u001b[39;00m\n\u001b[32m    211\u001b[39m \u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m213\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m np.hstack(\u001b[43m[\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mmatvec\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcol\u001b[49m\u001b[43m.\u001b[49m\u001b[43mreshape\u001b[49m\u001b[43m(\u001b[49m\u001b[43m-\u001b[49m\u001b[32;43m1\u001b[39;49m\u001b[43m,\u001b[49m\u001b[32;43m1\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mcol\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mX\u001b[49m\u001b[43m.\u001b[49m\u001b[43mT\u001b[49m\u001b[43m]\u001b[49m)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/_base.py:286\u001b[39m, in \u001b[36m_spbase.__iter__\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    285\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m r \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mrange\u001b[39m(\u001b[38;5;28mself\u001b[39m.shape[\u001b[32m0\u001b[39m]):\n\u001b[32m--> \u001b[39m\u001b[32m286\u001b[39m     \u001b[38;5;28;01myield\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m[\u001b[49m\u001b[43mr\u001b[49m\u001b[43m]\u001b[49m\n",
-      "\u001b[31mTypeError\u001b[39m: 'dia_array' object is not subscriptable",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:366\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    365\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m366\u001b[39m     Y = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_matmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    367\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:678\u001b[39m, in \u001b[36m_TransposedLinearOperator._matmat\u001b[39m\u001b[34m(self, x)\u001b[39m\n\u001b[32m    676\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_matmat\u001b[39m(\u001b[38;5;28mself\u001b[39m, x):\n\u001b[32m    677\u001b[39m     \u001b[38;5;66;03m# NB. np.conj works also on sparse matrices\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m678\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m np.conj(\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mA\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_rmatmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnp\u001b[49m\u001b[43m.\u001b[49m\u001b[43mconj\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:628\u001b[39m, in \u001b[36m_CustomLinearOperator._rmatmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    627\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m628\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_rmatmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:430\u001b[39m, in \u001b[36mLinearOperator._rmatmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    429\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m430\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mH\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmatmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:369\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    368\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m issparse(X) \u001b[38;5;129;01mor\u001b[39;00m is_pydata_spmatrix(X):\n\u001b[32m--> \u001b[39m\u001b[32m369\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\n\u001b[32m    370\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mUnable to multiply a LinearOperator with a sparse matrix.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    371\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m Wrap the matrix in aslinearoperator first.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    372\u001b[39m     ) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01me\u001b[39;00m\n\u001b[32m    373\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m\n",
-      "\u001b[31mTypeError\u001b[39m: Unable to multiply a LinearOperator with a sparse matrix. Wrap the matrix in aslinearoperator first.",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:366\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    365\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m366\u001b[39m     Y = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_matmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    367\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:774\u001b[39m, in \u001b[36m_ScaledLinearOperator._matmat\u001b[39m\u001b[34m(self, x)\u001b[39m\n\u001b[32m    773\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_matmat\u001b[39m(\u001b[38;5;28mself\u001b[39m, x):\n\u001b[32m--> \u001b[39m\u001b[32m774\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m.args[\u001b[32m1\u001b[39m] * \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43margs\u001b[49m\u001b[43m[\u001b[49m\u001b[32;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmatmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:369\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    368\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m issparse(X) \u001b[38;5;129;01mor\u001b[39;00m is_pydata_spmatrix(X):\n\u001b[32m--> \u001b[39m\u001b[32m369\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\n\u001b[32m    370\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mUnable to multiply a LinearOperator with a sparse matrix.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    371\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m Wrap the matrix in aslinearoperator first.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    372\u001b[39m     ) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01me\u001b[39;00m\n\u001b[32m    373\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m\n",
-      "\u001b[31mTypeError\u001b[39m: Unable to multiply a LinearOperator with a sparse matrix. Wrap the matrix in aslinearoperator first.",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[10]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mdata_misfit\u001b[49m\u001b[43m.\u001b[49m\u001b[43mhessian\u001b[49m\u001b[43m(\u001b[49m\u001b[43minitial_model\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/git/inversion-design-ideas/src/inversion_ideas/data_misfit.py:52\u001b[39m, in \u001b[36mDataMisfit.hessian\u001b[39m\u001b[34m(self, model)\u001b[39m\n\u001b[32m     48\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m     49\u001b[39m \u001b[33;03mHessian matrix.\u001b[39;00m\n\u001b[32m     50\u001b[39m \u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m     51\u001b[39m jac = \u001b[38;5;28mself\u001b[39m.simulation.jacobian(model)\n\u001b[32m---> \u001b[39m\u001b[32m52\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[32;43m2\u001b[39;49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m \u001b[49m\u001b[43mjac\u001b[49m\u001b[43m.\u001b[49m\u001b[43mT\u001b[49m\u001b[43m \u001b[49m\u001b[43m@\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mweights_squared\u001b[49m @ jac\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:479\u001b[39m, in \u001b[36mLinearOperator.__matmul__\u001b[39m\u001b[34m(self, other)\u001b[39m\n\u001b[32m    476\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m np.isscalar(other):\n\u001b[32m    477\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33m\"\u001b[39m\u001b[33mScalar operands are not allowed, \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    478\u001b[39m                      \u001b[33m\"\u001b[39m\u001b[33muse \u001b[39m\u001b[33m'\u001b[39m\u001b[33m*\u001b[39m\u001b[33m'\u001b[39m\u001b[33m instead\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m--> \u001b[39m\u001b[32m479\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[34;43m__mul__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mother\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:436\u001b[39m, in \u001b[36mLinearOperator.__mul__\u001b[39m\u001b[34m(self, x)\u001b[39m\n\u001b[32m    435\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m__mul__\u001b[39m(\u001b[38;5;28mself\u001b[39m, x):\n\u001b[32m--> \u001b[39m\u001b[32m436\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mdot\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:471\u001b[39m, in \u001b[36mLinearOperator.dot\u001b[39m\u001b[34m(self, x)\u001b[39m\n\u001b[32m    469\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m.matvec(x)\n\u001b[32m    470\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m x.ndim == \u001b[32m2\u001b[39m:\n\u001b[32m--> \u001b[39m\u001b[32m471\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mmatmat\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    472\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    473\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m'\u001b[39m\u001b[33mexpected 1-d or 2-d array or matrix, got \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mx\u001b[38;5;132;01m!r}\u001b[39;00m\u001b[33m'\u001b[39m)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/.miniforge3/envs/inversion_ideas/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:369\u001b[39m, in \u001b[36mLinearOperator.matmat\u001b[39m\u001b[34m(self, X)\u001b[39m\n\u001b[32m    367\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m    368\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m issparse(X) \u001b[38;5;129;01mor\u001b[39;00m is_pydata_spmatrix(X):\n\u001b[32m--> \u001b[39m\u001b[32m369\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\n\u001b[32m    370\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33mUnable to multiply a LinearOperator with a sparse matrix.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    371\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33m Wrap the matrix in aslinearoperator first.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    372\u001b[39m         ) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01me\u001b[39;00m\n\u001b[32m    373\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m\n\u001b[32m    375\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(Y, np.matrix):\n",
-      "\u001b[31mTypeError\u001b[39m: Unable to multiply a LinearOperator with a sparse matrix. Wrap the matrix in aslinearoperator first."
-     ]
-    }
-   ],
-   "source": [
-    "data_misfit.hessian(initial_model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5cc54476-cd31-4bf6-bc0f-bfd6254af7ec",
-   "metadata": {},
-   "source": [
-    "## Minimize manually with `scipy.sparse.linalg.cg`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "d4bac3a2-49d5-4592-a793-72789ec31a5c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.564296Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.564102Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.570018Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.569178Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.564276Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from scipy.sparse.linalg import cg"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "c3369162-abe9-4fb9-9294-69277e50ef13",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.571299Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.570942Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.580311Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.579716Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.571263Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "grad = phi.gradient(initial_model)\n",
-    "hess = phi.hessian(initial_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "c1fed88c-9c34-4ee3-8208-e7b50c2ec678",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.581353Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.581065Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.590994Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.590280Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.581322Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(array([0.81328361, 0.65926983, 0.24729306, 0.19624665, 0.32373823,\n",
-       "        0.14720994, 0.31944798, 0.25236328, 0.52215617, 0.92180399]),\n",
-       " 0)"
-      ]
-     },
      "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "model_step, info = cg(hess, -grad)\n",
-    "model_step, info"
+    "smallness = TikhonovZero(n_params)\n",
+    "phi = data_misfit + 1e-3 * smallness\n",
+    "phi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32a63320-8c51-487a-ae6f-17137923aa80",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:23:02.932872Z",
+     "iopub.status.busy": "2025-07-30T20:23:02.932454Z",
+     "iopub.status.idle": "2025-07-30T20:23:02.939709Z",
+     "shell.execute_reply": "2025-07-30T20:23:02.938340Z",
+     "shell.execute_reply.started": "2025-07-30T20:23:02.932834Z"
+    }
+   },
+   "source": [
+    "The hessian of `phi` should also be a dense array"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "54a8ef70-6e5f-4000-ad2f-658dbffd83f1",
+   "id": "539be41d-3b9f-47fb-bab1-d070b5321b23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.592437Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.591894Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.598507Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.597755Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.592402Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "inverted_model = initial_model + model_step"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "b05f913f-dcfa-4bca-a277-b9cf5c9de6b5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.599803Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.599475Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.607380Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.606608Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.599770Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result:\n",
-      "[0.81328361 0.65926983 0.24729306 0.19624665 0.32373823 0.14720994\n",
-      " 0.31944798 0.25236328 0.52215617 0.92180399]\n",
-      "\n",
-      "True model:\n",
-      "[0.78225148 0.67148671 0.2373809  0.17946133 0.34662367 0.15210999\n",
-      " 0.31142952 0.23900652 0.54355731 0.91770851]\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"Result:\")\n",
-    "print(inverted_model)\n",
-    "print()\n",
-    "print(\"True model:\")\n",
-    "print(true_model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ad0f7d22-77d6-410c-bca1-e3d765006aff",
-   "metadata": {},
-   "source": [
-    "## Minimize with SciPy's `minimize`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "5f36ec3b-0380-4eeb-b01a-3191c12b70f5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.608344Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.608101Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.720380Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.719607Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.608321Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from scipy.optimize import minimize"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "ba337ea8-0afb-46aa-b107-07bcf86a8324",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.721392Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.721124Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.840698Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.839910Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.721368Z"
-    }
+     "iopub.execute_input": "2025-07-30T20:30:47.700743Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.700520Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.705781Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.704996Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.700724Z"
+    },
+    "scrolled": true
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "  message: Optimization terminated successfully.\n",
-       "  success: True\n",
-       "   status: 0\n",
-       "      fun: 0.37159603111570305\n",
-       "        x: [ 8.133e-01  6.592e-01  2.473e-01  1.963e-01  3.237e-01\n",
-       "             1.472e-01  3.195e-01  2.524e-01  5.222e-01  9.218e-01]\n",
-       "      nit: 16\n",
-       "      jac: [-1.378e-07  2.645e-07  1.155e-07  1.118e-08 -1.006e-07\n",
-       "             1.714e-07 -3.725e-08  2.682e-07  3.353e-08  1.602e-07]\n",
-       " hess_inv: [[ 1.077e-02 -3.331e-03 ...  5.039e-04 -2.987e-03]\n",
-       "            [-3.331e-03  1.286e-02 ... -3.213e-03 -4.085e-04]\n",
-       "            ...\n",
-       "            [ 5.039e-04 -3.213e-03 ...  6.867e-03 -1.745e-03]\n",
-       "            [-2.987e-03 -4.085e-04 ... -1.745e-03  8.357e-03]]\n",
-       "     nfev: 231\n",
-       "     njev: 21"
+       "<10x10 _SumLinearOperator with dtype=float64>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "result =  minimize(phi, initial_model)\n",
-    "result"
+    "phi.hessian(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3159fc1-b1cf-46b9-8134-80c296bbea8a",
+   "metadata": {},
+   "source": [
+    "## Linear regressor with jacobian as a linear operator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b105b9be-bcdb-412f-8bfa-9d37c2319388",
+   "metadata": {},
+   "source": [
+    "Define the simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "37a7dba0-54c2-4e99-8fa6-7b641ef24117",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:30:47.706871Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.706608Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.710231Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.709467Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.706843Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "simulation = LinearRegressor(X, linop=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b75ec53-cfaf-4cc1-88a4-d41e93adb1b2",
+   "metadata": {},
+   "source": [
+    "Evaluate the jacobian"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "a498913b-88ad-4d65-b1bb-5544d4adff1f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:30:47.711431Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.710997Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.716054Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.715157Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.711400Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<25x10 _CustomLinearOperator with dtype=float64>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simulation.jacobian(model)  # should return a linear operator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d9939f63-73e8-4d4d-b612-e7705b0a0d80",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:30:47.717250Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.716940Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.721234Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.720451Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.717221Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "assert np.allclose(simulation(model), simulation.jacobian(model) @ model)  # true because the simulation is linear"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fefc832b-9292-42c8-b6b0-4acdc788f549",
+   "metadata": {},
+   "source": [
+    "Define a data misfit"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "d5cf83b5-6cbd-42d1-9513-d3ca38464b72",
+   "id": "32293774-f679-4591-a305-204be136b695",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.841743Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.841366Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.845304Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.844651Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.841708Z"
+     "iopub.execute_input": "2025-07-30T20:30:47.722324Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.722014Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.726204Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.725560Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.722302Z"
     }
    },
    "outputs": [],
    "source": [
-    "# The minimize already gives you the minimum model\n",
-    "inverted_model = result.x"
+    "uncertainty = 1e-2 * maxabs * np.ones_like(synthetic_data)\n",
+    "data_misfit = DataMisfit(synthetic_data, uncertainty, simulation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd99404c-f45d-4b23-9bac-60fc85ba43a4",
+   "metadata": {},
+   "source": [
+    "The gradient of the data misfit is a vector"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "d25be88b-3134-447a-b003-c80dddff3166",
+   "id": "fc98c2da-2196-4aaa-8885-f11a8c839d32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.846649Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.845928Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.855068Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.854320Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.846613Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result:\n",
-      "[0.81325615 0.65924881 0.24726449 0.19626688 0.32373389 0.14719947\n",
-      " 0.31947497 0.25235411 0.5221697  0.92183533]\n",
-      "\n",
-      "True model:\n",
-      "[0.78225148 0.67148671 0.2373809  0.17946133 0.34662367 0.15210999\n",
-      " 0.31142952 0.23900652 0.54355731 0.91770851]\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"Result:\")\n",
-    "print(inverted_model)\n",
-    "print()\n",
-    "print(\"True model:\")\n",
-    "print(true_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "50cb98a1-1fc8-4378-a517-09ed910ce1c3",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.856190Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.855868Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.891088Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.890143Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.856166Z"
+     "iopub.execute_input": "2025-07-30T20:30:47.727004Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.726811Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.731710Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.730961Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.726986Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       " message: Optimization terminated successfully.\n",
-       " success: True\n",
-       "  status: 0\n",
-       "     fun: 0.3715960311156836\n",
-       "       x: [ 8.133e-01  6.592e-01  2.473e-01  1.963e-01  3.237e-01\n",
-       "            1.472e-01  3.195e-01  2.524e-01  5.222e-01  9.218e-01]\n",
-       "     nit: 12\n",
-       "     jac: [ 3.612e-12  7.223e-12  7.137e-12  4.872e-12  5.592e-12\n",
-       "            6.519e-12  6.291e-12  7.993e-12  6.342e-12  8.719e-12]\n",
-       "    nfev: 24\n",
-       "    njev: 24"
+       "array([-571.55938062, -574.94129596, -500.28936815, -448.79630088,\n",
+       "       -532.78827694, -533.01745238, -575.12462734, -486.11230303,\n",
+       "       -639.0398147 , -732.49096897])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_misfit.gradient(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9191c3e-2c0f-4d29-abf5-a20db2d64a4c",
+   "metadata": {},
+   "source": [
+    "The hessian in this case should be a linear operator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "b2c95d58-fdc8-4cc9-b5f3-ddb86276d5f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:30:47.733147Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.732740Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.738953Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.738099Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.733117Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<10x10 _ProductLinearOperator with dtype=float64>"
       ]
      },
      "execution_count": 18,
@@ -601,260 +683,104 @@
     }
    ],
    "source": [
-    "result =  minimize(phi, initial_model, jac=phi.gradient, method=\"CG\")\n",
-    "result"
+    "data_misfit.hessian(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c7ca271-15d4-407c-b47a-4de674fe89a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:22:47.527483Z",
+     "iopub.status.busy": "2025-07-30T20:22:47.526618Z",
+     "iopub.status.idle": "2025-07-30T20:22:47.540681Z",
+     "shell.execute_reply": "2025-07-30T20:22:47.538612Z",
+     "shell.execute_reply.started": "2025-07-30T20:22:47.527411Z"
+    }
+   },
+   "source": [
+    "Define an objective function with regularization"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "45a7c13a-79ea-445f-b63d-b551787ebc20",
+   "id": "8c26274f-6907-4f7b-9378-dc9af36313d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.892479Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.892090Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.895990Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.895283Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.892440Z"
+     "iopub.execute_input": "2025-07-30T20:30:47.740214Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.739864Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.744935Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.744295Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.740182Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\phi (m)$ + $1.00 \\cdot 10^{-3} \\, \\phi (m)$"
+      ],
+      "text/plain": [
+       "φ(m) + 0.00 φ(m)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# The minimize already gives you the minimum model\n",
-    "inverted_model = result.x"
+    "smallness = TikhonovZero(n_params)\n",
+    "phi = data_misfit + 1e-3 * smallness\n",
+    "phi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfd4daec-4081-474f-b8bf-038d9f673c7c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-30T20:23:02.932872Z",
+     "iopub.status.busy": "2025-07-30T20:23:02.932454Z",
+     "iopub.status.idle": "2025-07-30T20:23:02.939709Z",
+     "shell.execute_reply": "2025-07-30T20:23:02.938340Z",
+     "shell.execute_reply.started": "2025-07-30T20:23:02.932834Z"
+    }
+   },
+   "source": [
+    "The hessian of `phi` should also be a linear operator"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "094fbf19-b676-4aba-8e23-b93abb8b2431",
+   "id": "4805f3ac-d185-4331-8eb9-92e860e4eb0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.897061Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.896763Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.906265Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.905380Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.897031Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result:\n",
-      "[0.81325615 0.65924881 0.2472645  0.19626689 0.32373389 0.14719947\n",
-      " 0.31947497 0.25235411 0.5221697  0.92183533]\n",
-      "\n",
-      "True model:\n",
-      "[0.78225148 0.67148671 0.2373809  0.17946133 0.34662367 0.15210999\n",
-      " 0.31142952 0.23900652 0.54355731 0.91770851]\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"Result:\")\n",
-    "print(result.x)\n",
-    "print()\n",
-    "print(\"True model:\")\n",
-    "print(true_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "65235b83-fd51-4f52-b7ba-3c0dc2a35fe2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.909944Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.909618Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.951403Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.950711Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.909917Z"
-    }
+     "iopub.execute_input": "2025-07-30T20:30:47.746389Z",
+     "iopub.status.busy": "2025-07-30T20:30:47.745769Z",
+     "iopub.status.idle": "2025-07-30T20:30:47.751999Z",
+     "shell.execute_reply": "2025-07-30T20:30:47.751294Z",
+     "shell.execute_reply.started": "2025-07-30T20:30:47.746358Z"
+    },
+    "scrolled": true
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       " message: Optimization terminated successfully.\n",
-       " success: True\n",
-       "  status: 0\n",
-       "     fun: 0.3715960311172809\n",
-       "       x: [ 8.133e-01  6.592e-01  2.473e-01  1.963e-01  3.237e-01\n",
-       "            1.472e-01  3.195e-01  2.524e-01  5.222e-01  9.218e-01]\n",
-       "     nit: 10\n",
-       "     jac: [-1.755e-04 -1.486e-04  1.521e-04  4.685e-05  3.222e-05\n",
-       "           -1.612e-04  8.816e-05  7.859e-06  3.653e-04 -1.935e-04]\n",
-       "    nfev: 11\n",
-       "    njev: 11\n",
-       "    nhev: 10"
+       "<10x10 _SumLinearOperator with dtype=float64>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "result =  minimize(phi, initial_model, jac=phi.gradient, hess=phi.hessian, method=\"Newton-CG\")\n",
-    "result"
+    "phi.hessian(model)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "45df89b6-58fc-472c-bfa6-96f1d3c7cc5c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.952542Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.952189Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.956340Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.955516Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.952505Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# The minimize already gives you the minimum model\n",
-    "inverted_model = result.x"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "2e9d2ee1-bfd9-4c3d-9865-f63d08a25b07",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.957539Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.957156Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.966604Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.965778Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.957497Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result:\n",
-      "[0.81325626 0.65924868 0.24726445 0.19626684 0.32373384 0.14719954\n",
-      " 0.31947496 0.25235426 0.52216973 0.92183526]\n",
-      "\n",
-      "True model:\n",
-      "[0.78225148 0.67148671 0.2373809  0.17946133 0.34662367 0.15210999\n",
-      " 0.31142952 0.23900652 0.54355731 0.91770851]\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"Result:\")\n",
-    "print(result.x)\n",
-    "print()\n",
-    "print(\"True model:\")\n",
-    "print(true_model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ded8a6fd-c419-4b13-bf3e-9d221c78a368",
-   "metadata": {},
-   "source": [
-    "## Use `Minimizer` class"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "34372a3f-ff42-435f-9423-a4f99712fd9c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.967786Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.967434Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.975769Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.974822Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.967749Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<inversion_ideas.minimizer.ConjugateGradient at 0x7fd33143a7b0>"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minimizer = ConjugateGradient()\n",
-    "minimizer"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "id": "f3f52071-c2c5-4016-9d61-cd2f3b781698",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.977062Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.976761Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.983704Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.983111Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.977038Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "inverted_model = minimizer(phi, initial_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "e41d3e15-1a74-42b9-9583-cacb8aeceadc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-23T16:35:11.984622Z",
-     "iopub.status.busy": "2025-07-23T16:35:11.984347Z",
-     "iopub.status.idle": "2025-07-23T16:35:11.992186Z",
-     "shell.execute_reply": "2025-07-23T16:35:11.991340Z",
-     "shell.execute_reply.started": "2025-07-23T16:35:11.984589Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result:\n",
-      "[0.81328361 0.65926983 0.24729306 0.19624665 0.32373823 0.14720994\n",
-      " 0.31944798 0.25236328 0.52215617 0.92180399]\n",
-      "\n",
-      "True model:\n",
-      "[0.78225148 0.67148671 0.2373809  0.17946133 0.34662367 0.15210999\n",
-      " 0.31142952 0.23900652 0.54355731 0.91770851]\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"Result:\")\n",
-    "print(inverted_model)\n",
-    "print()\n",
-    "print(\"True model:\")\n",
-    "print(true_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4a35232d-899c-4746-884d-58cb6b60a52d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/regressor.py
+++ b/notebooks/regressor.py
@@ -3,6 +3,7 @@ Inversion framework to implement a linear regressor.
 """
 import numpy as np
 from numpy.typing import NDArray
+from scipy.sparse.linalg import LinearOperator
 
 from inversion_ideas import Simulation
 
@@ -16,8 +17,9 @@ class LinearRegressor(Simulation):
         \mathbf{y} = \mathbf{X} \cdot \mathbf{m}
     """
 
-    def __init__(self, X):
+    def __init__(self, X, linop=False):
         self.X = X
+        self.linop = linop
 
     @property
     def n_params(self) -> int:
@@ -43,4 +45,12 @@ class LinearRegressor(Simulation):
         """
         Jacobian matrix for a given model.
         """
+        if self.linop:
+            linear_op = LinearOperator(
+                shape=(self.n_data, self.n_params),
+                matvec=lambda model: self.X @ model,
+                rmatvec=lambda model: self.X.T @ model,
+                dtype=np.float64,
+            )
+            return linear_op
         return self.X

--- a/notebooks/regressor.py
+++ b/notebooks/regressor.py
@@ -41,7 +41,7 @@ class LinearRegressor(Simulation):
         """
         return self.X @ model
 
-    def jacobian(self, model):  # noqa: ARG002
+    def jacobian(self, model) -> NDArray[np.float64] | LinearOperator:  # noqa: ARG002
         """
         Jacobian matrix for a given model.
         """

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -58,7 +58,7 @@ class DataMisfit(Objective):
         jac = self.simulation.jacobian(model)
         return -2 * jac.T @ (self.weights_squared @ self.residual(model))
 
-    def hessian(self, model) -> npt.NDarray[np.float64] | sparray | LinearOperator:
+    def hessian(self, model) -> npt.NDArray[np.float64] | sparray | LinearOperator:
         """
         Hessian matrix.
         """

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -42,7 +42,7 @@ class DataMisfit(Objective):
         Gradient vector.
         """
         jac = self.simulation.jacobian(model)
-        return -2 * jac.T @ self.weights_squared @ self.residual(model)
+        return -2 * jac.T @ (self.weights_squared @ self.residual(model))
 
     def hessian(self, model):
         """

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -1,9 +1,11 @@
 """
 Class to represent a data misfit term.
 """
-import time
+import numpy as np
+import numpy.typing as npt
 
-from scipy.sparse import diags_array
+from scipy.sparse import diags_array, sparray
+from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 from .objective_function import Objective
 from .utils import cache_on_model
@@ -24,32 +26,46 @@ class DataMisfit(Objective):
     cache : bool, optional
         Whether to cache the last result of the `__call__` method.
         Default to False.
+    build_hessian : bool, optional
+        If True, the ``hessian`` method will build the Hessian matrix and allocate it in
+        memory. If False, the ``hessian`` method will return a linear operator that
+        represents the Hessian matrix. Default to False.
+
+        .. important::
+
+            Hessian matrices are usually very large. Use ``build_hessian=True`` only if
+            you need to build it.
     """
 
-    def __init__(self, data, uncertainty, simulation, *, cache=False):
+    def __init__(
+        self, data, uncertainty, simulation, *, cache=False, build_hessian=False
+    ):
         self.data = data
         self.uncertainty = uncertainty
         self.simulation = simulation
         self.cache = cache
+        self.build_hessian = build_hessian
 
     @cache_on_model
     def __call__(self, model) -> float:
         residual = self.residual(model)
         return residual.T @ self.weights_squared @ residual
 
-    def gradient(self, model):
+    def gradient(self, model) -> npt.NDArray[np.float64]:
         """
         Gradient vector.
         """
         jac = self.simulation.jacobian(model)
         return -2 * jac.T @ (self.weights_squared @ self.residual(model))
 
-    def hessian(self, model):
+    def hessian(self, model) -> npt.NDarray[np.float64] | sparray | LinearOperator:
         """
         Hessian matrix.
         """
         jac = self.simulation.jacobian(model)
-        return 2 * jac.T @ self.weights_squared @ jac
+        if not self.build_hessian:
+            jac = aslinearoperator(jac)
+        return 2 * jac.T @ aslinearoperator(self.weights_squared) @ jac
 
     @property
     def n_params(self):

--- a/src/inversion_ideas/inversion.py
+++ b/src/inversion_ideas/inversion.py
@@ -215,7 +215,7 @@ class InversionLog:
         Inversion log.
         """
         if not hasattr(self, "_log"):
-            self._log = {col: [] for col in self.columns}
+            self._log: dict[str, list] = {col: [] for col in self.columns}
         return self._log
 
     def _update_log(self, iteration: int, model: npt.NDArray[np.float64]):

--- a/src/inversion_ideas/objective_function.py
+++ b/src/inversion_ideas/objective_function.py
@@ -253,7 +253,9 @@ def _get_n_params(functions: list) -> int:
     return n_params
 
 
-def _sum(operators: Iterator[npt.NDArray | sparray | LinearOperator]):
+def _sum(
+    operators: Iterator[npt.NDArray | sparray | LinearOperator],
+) -> npt.NDArray | sparray | LinearOperator:
     """
     Sum objects within an iterator.
 

--- a/src/inversion_ideas/objective_function.py
+++ b/src/inversion_ideas/objective_function.py
@@ -122,7 +122,9 @@ class Scaled(Objective):
         """
         return self.multiplier * self.function.gradient(model)
 
-    def hessian(self, model: npt.NDArray) -> npt.NDArray[np.float64] | sparray:
+    def hessian(
+        self, model: npt.NDArray
+    ) -> npt.NDArray[np.float64] | sparray | LinearOperator:
         """
         Evaluate the hessian of the objective function for a given model.
         """

--- a/src/inversion_ideas/objective_function.py
+++ b/src/inversion_ideas/objective_function.py
@@ -212,7 +212,7 @@ class Combo(Objective):
         return " + ".join(f._repr_latex_() for f in self.functions)
 
 
-def _unpack_combo(functions: list) -> list:
+def _unpack_combo(functions: Iterable) -> list:
     """
     Unpack combo objective functions.
     """

--- a/src/inversion_ideas/simulation.py
+++ b/src/inversion_ideas/simulation.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 from numpy.typing import NDArray
+from scipy.sparse.linalg import LinearOperator
 
 
 class Simulation(ABC):
@@ -37,7 +38,7 @@ class Simulation(ABC):
         """
 
     @abstractmethod
-    def jacobian(self, model):
+    def jacobian(self, model) -> NDArray[np.float64] | LinearOperator:
         """
         Jacobian matrix for a given model.
         """

--- a/tests/test_objective_functions.py
+++ b/tests/test_objective_functions.py
@@ -1,0 +1,108 @@
+"""
+Test operations for objective functions.
+"""
+import pytest
+import numpy as np
+from scipy.sparse import diags_array, sparray
+from scipy.sparse.linalg import aslinearoperator, LinearOperator
+
+from inversion_ideas.objective_function import _sum
+
+
+class TestSum:
+    """
+    Test custom sum for operators.
+
+    Test cases:
+
+        - All arrays, should return array.
+        - One sparse array, should return array.
+        - All sparse arrays, should return sparse array.
+        - One linear operator, should return linear operator.
+        - Put the special objects ones in the beginning and in the middle of the
+          generator.
+    """
+
+    shape = (25, 10)
+
+    @pytest.fixture
+    def matrices(self):
+        seeds = (40, 41, 42)
+        a, b, c = tuple(
+            np.random.default_rng(seed=seed).uniform(size=self.shape) for seed in seeds
+        )
+        return a, b, c
+
+    @pytest.fixture
+    def sparse_arrays(self):
+        seeds = (40, 41, 42)
+        a, b, c = tuple(
+            diags_array(
+                np.random.default_rng(seed=seed).uniform(size=self.shape[0]),
+                shape=self.shape,
+            )
+            for seed in seeds
+        )
+        return a, b, c
+
+    @pytest.fixture
+    def vector(self):
+        return np.random.default_rng(seed=43).uniform(size=self.shape[1])
+
+    def test_all_arrays(self, matrices):
+        # Get the sum
+        result = _sum(op for op in matrices)
+
+        # We should recover a dense array
+        assert isinstance(result, np.ndarray)
+
+        # Check if result is correct
+        a, b, c = matrices
+        expected = a + b + c
+        np.testing.assert_allclose(result, expected)
+
+    @pytest.mark.parametrize("index", [0, 1])
+    def test_one_sparse_array(self, matrices, index):
+        # Put a sparse array in the list of operators
+        operators = list(matrices)
+        operators[index] = diags_array(np.arange(self.shape[1]), shape=self.shape)
+
+        # Get the sum
+        result = _sum(op for op in operators)
+
+        # We should recover a dense array
+        assert isinstance(result, np.ndarray)
+
+        # Check if result is correct
+        a, b, c = operators
+        expected = a + b + c
+        np.testing.assert_allclose(result, expected)
+
+    def test_all_sparse_arrays(self, sparse_arrays):
+        result = _sum(op for op in sparse_arrays)
+
+        # We should recover a sparse array
+        assert isinstance(result, sparray)
+
+        # Check if result is correct
+        a, b, c = sparse_arrays
+        expected = a + b + c
+        np.testing.assert_allclose(result.toarray(), expected.toarray())
+
+    @pytest.mark.parametrize("index", [0, 1])
+    def test_one_linear_operator(self, matrices, vector, index):
+        # Put a linear operator in the list of operators
+        operators = list(matrices)
+        factor = 5.1
+        operators[index] = factor * aslinearoperator(operators[index])
+
+        # Get the sum
+        result = _sum(op for op in operators)
+
+        # We should recover a linear operator
+        assert isinstance(result, LinearOperator)
+
+        # Check if result is correct
+        a, b, c = matrices
+        expected = factor * a + b + c if index == 0 else a + factor * b + c
+        np.testing.assert_allclose(result @ vector, expected @ vector)


### PR DESCRIPTION
Allow to `jacobian` method in simulations to be `LinearOperators`. Support objective functions that return `hessian` as a `LinearOperator`. Add a new `build_hessian` argument to `DataMisfit` through which users can decide whether they want the `hessian` method to allocate the Hessian matrix or define it as a `LinearOperator`. Improve some type hints, add some tests, rerun notebooks.
