### PR TITLE
Implement `__itruediv__` for `Scaled` functions

### DIFF
--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -90,18 +90,23 @@ class Objective(ABC):
     def __rmul__(self, value):
         return self.__mul__(value)
 
-    def __div__(self, denominator):
-        return self * (1.0 / denominator)
-
     def __truediv__(self, denominator):
         return self * (1.0 / denominator)
 
-    def __iadd__(self, other) -> "Combo":  # noqa: PYI034
+    def __floordiv__(self, denominator):
+        msg = "Floor division is not implemented for objective functions."
+        raise TypeError(msg)
+
+    def __iadd__(self, other) -> Self:
         msg = "Inplace addition is not implemented for this class."
         raise TypeError(msg)
 
-    def __imul__(self, other) -> "Scaled":  # noqa: PYI034
+    def __imul__(self, other) -> Self:
         msg = "Inplace multiplication is not implemented for this class."
+        raise TypeError(msg)
+
+    def __itruediv__(self, value) -> Self:
+        msg = "Inplace division is not implemented for this class."
         raise TypeError(msg)
 
 
@@ -169,6 +174,10 @@ class Scaled(Objective):
 
     def __imul__(self, value) -> Self:
         self.multiplier *= value
+        return self
+
+    def __itruediv__(self, value) -> Self:
+        self.multiplier /= value
         return self
 
 

--- a/tests/test_objective_functions.py
+++ b/tests/test_objective_functions.py
@@ -141,6 +141,7 @@ class TestObjectiveOperations:
             - Error on imul for Combo.
             - Error on iadd for Scaled.
             - imul works ok for Scaled.
+            - idiv works ok for Scaled.
             - iadd works ok for Combo.
     """
 
@@ -259,6 +260,27 @@ class TestObjectiveOperations:
             phi = phi + other
         with pytest.raises(TypeError):
             phi *= 2.71
+
+    def test_idiv_scaled(self):
+        a = Dummy(self.n_params)
+        scalar = 3.14
+        scaled = scalar * a
+        scaled_bkp = scaled
+        new_scalar = 4.0
+        scaled /= new_scalar
+        assert isinstance(scaled, Scaled)
+        assert scaled is scaled_bkp  # assert inplace operation
+        assert scaled.function is a
+        assert scaled.multiplier == scalar / new_scalar
+
+    @pytest.mark.parametrize("function_type", ["objective", "combo"])
+    def test_idiv_error(self, function_type):
+        phi = Dummy(self.n_params)
+        if function_type == "combo":
+            other = Dummy(self.n_params)
+            phi = phi + other
+        with pytest.raises(TypeError):
+            phi /= 2.71
 
 
 def test_combo_flatten():


### PR DESCRIPTION
Implement `__itruediv__` for objective functions: `Objective` and `Combo` raise a `TypeError`, `Scaled` modifies the multiplier in-place and returns a copy of itself. Replace the old `__div__` for the new `__truediv__` and `__floordiv__`. Make `__floordiv__` to raise a `TypeError` for every class.
