### PR TITLE
Add `initialize()` method to `Condition`s

### DIFF
--- a/notebooks/10_multiple-conditions.ipynb
+++ b/notebooks/10_multiple-conditions.ipynb
@@ -14,11 +14,11 @@
    "id": "eb4145ad-9d6a-411f-aa2e-7ab211a1f737",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:53.940759Z",
-     "iopub.status.busy": "2025-08-18T17:23:53.940456Z",
-     "iopub.status.idle": "2025-08-18T17:23:54.225520Z",
-     "shell.execute_reply": "2025-08-18T17:23:54.224966Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:53.940732Z"
+     "iopub.execute_input": "2025-08-19T21:41:04.669515Z",
+     "iopub.status.busy": "2025-08-19T21:41:04.669203Z",
+     "iopub.status.idle": "2025-08-19T21:41:04.945352Z",
+     "shell.execute_reply": "2025-08-19T21:41:04.944681Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:04.669484Z"
     }
    },
    "outputs": [],
@@ -53,11 +53,11 @@
    "id": "22f226e2-d715-49e8-b357-38e71d78bcdc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:54.226106Z",
-     "iopub.status.busy": "2025-08-18T17:23:54.225896Z",
-     "iopub.status.idle": "2025-08-18T17:23:54.232695Z",
-     "shell.execute_reply": "2025-08-18T17:23:54.232002Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:54.226089Z"
+     "iopub.execute_input": "2025-08-19T21:41:04.946145Z",
+     "iopub.status.busy": "2025-08-19T21:41:04.945883Z",
+     "iopub.status.idle": "2025-08-19T21:41:04.953331Z",
+     "shell.execute_reply": "2025-08-19T21:41:04.952578Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:04.946127Z"
     }
    },
    "outputs": [
@@ -86,11 +86,11 @@
    "id": "0e39a2d1-d26e-4ee2-8f9f-f3b33f1ac124",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:54.233791Z",
-     "iopub.status.busy": "2025-08-18T17:23:54.233422Z",
-     "iopub.status.idle": "2025-08-18T17:23:54.240691Z",
-     "shell.execute_reply": "2025-08-18T17:23:54.240025Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:54.233768Z"
+     "iopub.execute_input": "2025-08-19T21:41:04.954572Z",
+     "iopub.status.busy": "2025-08-19T21:41:04.954122Z",
+     "iopub.status.idle": "2025-08-19T21:41:04.964967Z",
+     "shell.execute_reply": "2025-08-19T21:41:04.964292Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:04.954540Z"
     }
    },
    "outputs": [],
@@ -107,11 +107,11 @@
    "id": "8f052ed5-3a2b-4f32-8b44-8a86ea278960",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:54.241630Z",
-     "iopub.status.busy": "2025-08-18T17:23:54.241343Z",
-     "iopub.status.idle": "2025-08-18T17:23:54.251154Z",
-     "shell.execute_reply": "2025-08-18T17:23:54.250541Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:54.241603Z"
+     "iopub.execute_input": "2025-08-19T21:41:04.965645Z",
+     "iopub.status.busy": "2025-08-19T21:41:04.965424Z",
+     "iopub.status.idle": "2025-08-19T21:41:04.991306Z",
+     "shell.execute_reply": "2025-08-19T21:41:04.990629Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:04.965627Z"
     }
    },
    "outputs": [
@@ -152,11 +152,11 @@
    "id": "ae80cc54-96f9-4a85-ad1f-9dce5dc38870",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:54.251883Z",
-     "iopub.status.busy": "2025-08-18T17:23:54.251701Z",
-     "iopub.status.idle": "2025-08-18T17:23:54.257609Z",
-     "shell.execute_reply": "2025-08-18T17:23:54.256978Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:54.251865Z"
+     "iopub.execute_input": "2025-08-19T21:41:04.992415Z",
+     "iopub.status.busy": "2025-08-19T21:41:04.992136Z",
+     "iopub.status.idle": "2025-08-19T21:41:05.000885Z",
+     "shell.execute_reply": "2025-08-19T21:41:05.000128Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:04.992385Z"
     }
    },
    "outputs": [],
@@ -172,11 +172,11 @@
    "id": "050b9c20-4b0a-49af-a900-1bb964588408",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:54.259923Z",
-     "iopub.status.busy": "2025-08-18T17:23:54.259634Z",
-     "iopub.status.idle": "2025-08-18T17:23:54.264841Z",
-     "shell.execute_reply": "2025-08-18T17:23:54.264096Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:54.259904Z"
+     "iopub.execute_input": "2025-08-19T21:41:05.003627Z",
+     "iopub.status.busy": "2025-08-19T21:41:05.003282Z",
+     "iopub.status.idle": "2025-08-19T21:41:05.010318Z",
+     "shell.execute_reply": "2025-08-19T21:41:05.009586Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:05.003595Z"
     }
    },
    "outputs": [],
@@ -190,11 +190,11 @@
    "id": "b6e3ea36-dc6b-4aa1-99b8-31721937d933",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:54.265767Z",
-     "iopub.status.busy": "2025-08-18T17:23:54.265518Z",
-     "iopub.status.idle": "2025-08-18T17:23:54.275120Z",
-     "shell.execute_reply": "2025-08-18T17:23:54.274507Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:54.265731Z"
+     "iopub.execute_input": "2025-08-19T21:41:05.011406Z",
+     "iopub.status.busy": "2025-08-19T21:41:05.011132Z",
+     "iopub.status.idle": "2025-08-19T21:41:05.017701Z",
+     "shell.execute_reply": "2025-08-19T21:41:05.016838Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:05.011376Z"
     }
    },
    "outputs": [],
@@ -226,11 +226,11 @@
    "id": "cf72d7ed-3565-466f-b13a-40a5d359eb9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:54.275851Z",
-     "iopub.status.busy": "2025-08-18T17:23:54.275668Z",
-     "iopub.status.idle": "2025-08-18T17:23:54.281858Z",
-     "shell.execute_reply": "2025-08-18T17:23:54.281247Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:54.275833Z"
+     "iopub.execute_input": "2025-08-19T21:41:05.018713Z",
+     "iopub.status.busy": "2025-08-19T21:41:05.018437Z",
+     "iopub.status.idle": "2025-08-19T21:41:05.024856Z",
+     "shell.execute_reply": "2025-08-19T21:41:05.024210Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:05.018684Z"
     }
    },
    "outputs": [],
@@ -251,18 +251,18 @@
    "id": "7a8ddaa6-42e3-44d4-8032-654f82b676c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:54.282817Z",
-     "iopub.status.busy": "2025-08-18T17:23:54.282546Z",
-     "iopub.status.idle": "2025-08-18T17:23:59.514283Z",
-     "shell.execute_reply": "2025-08-18T17:23:59.512108Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:54.282789Z"
+     "iopub.execute_input": "2025-08-19T21:41:05.025806Z",
+     "iopub.status.busy": "2025-08-19T21:41:05.025543Z",
+     "iopub.status.idle": "2025-08-19T21:41:10.235671Z",
+     "shell.execute_reply": "2025-08-19T21:41:10.234737Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:05.025777Z"
     }
    },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "72e403beb97b438e812b2881ced13575",
+       "model_id": "50a49723344b47d9a600a06150748a3a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -301,11 +301,11 @@
    "id": "9c9040bc-fca0-4654-a843-765c6a4c1b4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:59.516255Z",
-     "iopub.status.busy": "2025-08-18T17:23:59.515820Z",
-     "iopub.status.idle": "2025-08-18T17:23:59.524459Z",
-     "shell.execute_reply": "2025-08-18T17:23:59.523147Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:59.516218Z"
+     "iopub.execute_input": "2025-08-19T21:41:10.237217Z",
+     "iopub.status.busy": "2025-08-19T21:41:10.236799Z",
+     "iopub.status.idle": "2025-08-19T21:41:10.243189Z",
+     "shell.execute_reply": "2025-08-19T21:41:10.242245Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:10.237179Z"
     }
    },
    "outputs": [
@@ -330,11 +330,11 @@
    "id": "2e7c0859-554d-47bb-8e3f-20f261bb67e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:59.526014Z",
-     "iopub.status.busy": "2025-08-18T17:23:59.525588Z",
-     "iopub.status.idle": "2025-08-18T17:23:59.541181Z",
-     "shell.execute_reply": "2025-08-18T17:23:59.540314Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:59.525959Z"
+     "iopub.execute_input": "2025-08-19T21:41:10.245004Z",
+     "iopub.status.busy": "2025-08-19T21:41:10.244227Z",
+     "iopub.status.idle": "2025-08-19T21:41:10.257874Z",
+     "shell.execute_reply": "2025-08-19T21:41:10.257138Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:10.244966Z"
     }
    },
    "outputs": [
@@ -359,11 +359,11 @@
    "id": "53880cc0-fc58-4965-8e9f-1201fe302b28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-18T17:23:59.542247Z",
-     "iopub.status.busy": "2025-08-18T17:23:59.541985Z",
-     "iopub.status.idle": "2025-08-18T17:23:59.551141Z",
-     "shell.execute_reply": "2025-08-18T17:23:59.550369Z",
-     "shell.execute_reply.started": "2025-08-18T17:23:59.542217Z"
+     "iopub.execute_input": "2025-08-19T21:41:10.258705Z",
+     "iopub.status.busy": "2025-08-19T21:41:10.258471Z",
+     "iopub.status.idle": "2025-08-19T21:41:10.268130Z",
+     "shell.execute_reply": "2025-08-19T21:41:10.267481Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:10.258681Z"
     }
    },
    "outputs": [
@@ -380,6 +380,94 @@
    ],
    "source": [
     "phi_changed(inverted_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55937146-ef20-4d80-a03b-60d5cdefc4b0",
+   "metadata": {},
+   "source": [
+    "## Reuse conditions\n",
+    "\n",
+    "If we reuse the conditions, the new inversion should initialize the stopping criteria on the zeroth inversion, starting from fresh."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0cb8a52b-19f7-45b7-a4eb-3ed6df4a71b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-19T21:41:10.269398Z",
+     "iopub.status.busy": "2025-08-19T21:41:10.269054Z",
+     "iopub.status.idle": "2025-08-19T21:41:10.276628Z",
+     "shell.execute_reply": "2025-08-19T21:41:10.275840Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:10.269362Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Reset starting beta in the regularization\n",
+    "regularization.multiplier = 1e4\n",
+    "\n",
+    "inversion = Inversion(\n",
+    "    phi,\n",
+    "    initial_model,\n",
+    "    minimizer,\n",
+    "    directives=[beta_cooler],\n",
+    "    stopping_criteria=stopping_criteria,\n",
+    "    cache_models=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "14a40cb0-d5f9-44f8-ba1e-cd1f26908737",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-19T21:41:10.277551Z",
+     "iopub.status.busy": "2025-08-19T21:41:10.277313Z",
+     "iopub.status.idle": "2025-08-19T21:41:15.427083Z",
+     "shell.execute_reply": "2025-08-19T21:41:15.426242Z",
+     "shell.execute_reply.started": "2025-08-19T21:41:10.277527Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fd8dad1c834b4944b2a08b4be76cba4d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: 🎉 Inversion successfully finished due to stopping critiera.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "inverted_model = inversion.run()"
    ]
   }
  ],

--- a/src/inversion_ideas/base/conditions.py
+++ b/src/inversion_ideas/base/conditions.py
@@ -16,11 +16,20 @@ class Condition(ABC):
     """
 
     @abstractmethod
-    def __call__(self, model) -> bool: ...
+    def __call__(self, model) -> bool:
+        ...
 
     def update(self, model):  # noqa: B027
         """
         Update the condition.
+        """
+        # This is not an abstract method. Children classes can choose to override it if
+        # necessary. The base class implements it to provide a common interface, even
+        # for those children that don't implement it.
+
+    def initialize(self):  # noqa: B027
+        """
+        Initialize the condition.
         """
         # This is not an abstract method. Children classes can choose to override it if
         # necessary. The base class implements it to provide a common interface, even
@@ -64,6 +73,14 @@ class _Mixin:
         for condition in (self.condition_a, self.condition_b):
             if hasattr(condition, "update"):
                 condition.update(model)
+
+    def initialize(self):
+        """
+        Initialize the underlying conditions.
+        """
+        for condition in (self.condition_a, self.condition_b):
+            if hasattr(condition, "initialize"):
+                condition.initialize()
 
 
 class LogicalAnd(_Mixin, Condition):

--- a/src/inversion_ideas/conditions.py
+++ b/src/inversion_ideas/conditions.py
@@ -101,7 +101,16 @@ class ModelChanged(Condition):
         return diff <= max(previous * self.rtol, self.atol)
 
     def update(self, model):
+        """
+        Cache model as the ``previous`` one.
+        """
         self.previous = model
+
+    def initialize(self):
+        """
+        Initialize condition and clean ``previous`` attribute.
+        """
+        delattr(self, "previous")
 
 
 class ObjectiveChanged(Condition):
@@ -159,4 +168,13 @@ class ObjectiveChanged(Condition):
         return abs(diff) <= max(abs(self.previous) * self.rtol, self.atol)
 
     def update(self, model):
+        """
+        Cache value of objective function with model as the ``previous`` one.
+        """
         self.previous: float = float(self.objective_function(model))
+
+    def initialize(self):
+        """
+        Initialize condition and clean ``previous`` attribute.
+        """
+        delattr(self, "previous")

--- a/src/inversion_ideas/conditions.py
+++ b/src/inversion_ideas/conditions.py
@@ -110,7 +110,8 @@ class ModelChanged(Condition):
         """
         Initialize condition and clean ``previous`` attribute.
         """
-        delattr(self, "previous")
+        if hasattr(self, "previous"):
+            delattr(self, "previous")
 
 
 class ObjectiveChanged(Condition):
@@ -177,4 +178,5 @@ class ObjectiveChanged(Condition):
         """
         Initialize condition and clean ``previous`` attribute.
         """
-        delattr(self, "previous")
+        if hasattr(self, "previous"):
+            delattr(self, "previous")

--- a/src/inversion_ideas/inversion.py
+++ b/src/inversion_ideas/inversion.py
@@ -90,9 +90,12 @@ class Inversion:
         """
         Run next iteration in the inversion.
         """
-        # Add initial model to log (only on zeroth iteration)
         if self.counter == 0 and self.log is not None:
+            # Add initial model to log (only on zeroth iteration)
             self.log.update(self.counter, self.model)
+            # Initialize stopping criteria (if necessary)
+            if hasattr(self.stopping_criteria, "initialize"):
+                self.stopping_criteria.initialize()
 
         # Check for stopping criteria before trying to run the iteration
         if self.stopping_criteria(self.model):


### PR DESCRIPTION
The `initialize` method is intended to clean pre-stored attributes, so any time a condition is reused, we can clean it and start fresh. Make `Inversion` to run `stopping_criteria.initialize()` on the zeroth iteration. Rerun inversion in notebook 10.
