### PR TITLE
Add `JacobiPreconditioner` class

### DIFF
--- a/notebooks/11_gravity-inversion-with-preconditioner.ipynb
+++ b/notebooks/11_gravity-inversion-with-preconditioner.ipynb
@@ -14,10 +14,11 @@
    "id": "b2d27e8b-5b33-4361-990b-8b6e724f5ac6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:12.534609Z",
-     "iopub.status.busy": "2025-08-29T00:36:12.533564Z",
-     "iopub.status.idle": "2025-08-29T00:36:14.228764Z",
-     "shell.execute_reply": "2025-08-29T00:36:14.228167Z"
+     "iopub.execute_input": "2025-08-29T17:53:52.894322Z",
+     "iopub.status.busy": "2025-08-29T17:53:52.893824Z",
+     "iopub.status.idle": "2025-08-29T17:53:54.617481Z",
+     "shell.execute_reply": "2025-08-29T17:53:54.616826Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:52.894276Z"
     }
    },
    "outputs": [],
@@ -55,10 +56,11 @@
    "id": "dfce90d3-de10-43d3-a668-696993b0f73e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:14.230795Z",
-     "iopub.status.busy": "2025-08-29T00:36:14.230484Z",
-     "iopub.status.idle": "2025-08-29T00:36:14.234182Z",
-     "shell.execute_reply": "2025-08-29T00:36:14.233706Z"
+     "iopub.execute_input": "2025-08-29T17:53:54.618798Z",
+     "iopub.status.busy": "2025-08-29T17:53:54.618307Z",
+     "iopub.status.idle": "2025-08-29T17:53:54.623750Z",
+     "shell.execute_reply": "2025-08-29T17:53:54.622953Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:54.618770Z"
     }
    },
    "outputs": [],
@@ -81,10 +83,11 @@
    "id": "2403d600-451e-424e-8de9-3f824f1e2647",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:14.235750Z",
-     "iopub.status.busy": "2025-08-29T00:36:14.235546Z",
-     "iopub.status.idle": "2025-08-29T00:36:15.528000Z",
-     "shell.execute_reply": "2025-08-29T00:36:15.527435Z"
+     "iopub.execute_input": "2025-08-29T17:53:54.625206Z",
+     "iopub.status.busy": "2025-08-29T17:53:54.624575Z",
+     "iopub.status.idle": "2025-08-29T17:53:55.965239Z",
+     "shell.execute_reply": "2025-08-29T17:53:55.964568Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:54.625168Z"
     }
    },
    "outputs": [
@@ -113,10 +116,11 @@
    "id": "9612913a-b699-4ad4-8fe7-cbf83376f5d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:15.529613Z",
-     "iopub.status.busy": "2025-08-29T00:36:15.529447Z",
-     "iopub.status.idle": "2025-08-29T00:36:15.665338Z",
-     "shell.execute_reply": "2025-08-29T00:36:15.664804Z"
+     "iopub.execute_input": "2025-08-29T17:53:55.966046Z",
+     "iopub.status.busy": "2025-08-29T17:53:55.965802Z",
+     "iopub.status.idle": "2025-08-29T17:53:56.114031Z",
+     "shell.execute_reply": "2025-08-29T17:53:56.113546Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:55.966024Z"
     }
    },
    "outputs": [
@@ -144,10 +148,11 @@
    "id": "f6d55c30-c5c9-4376-bc6d-ece83805b2d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:15.666953Z",
-     "iopub.status.busy": "2025-08-29T00:36:15.666781Z",
-     "iopub.status.idle": "2025-08-29T00:36:15.669996Z",
-     "shell.execute_reply": "2025-08-29T00:36:15.669650Z"
+     "iopub.execute_input": "2025-08-29T17:53:56.114891Z",
+     "iopub.status.busy": "2025-08-29T17:53:56.114621Z",
+     "iopub.status.idle": "2025-08-29T17:53:56.118601Z",
+     "shell.execute_reply": "2025-08-29T17:53:56.118146Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:56.114873Z"
     }
    },
    "outputs": [
@@ -180,10 +185,11 @@
    "id": "0edbb620-6a62-48bf-a8af-8981a76cc6f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:15.671441Z",
-     "iopub.status.busy": "2025-08-29T00:36:15.671280Z",
-     "iopub.status.idle": "2025-08-29T00:36:15.675481Z",
-     "shell.execute_reply": "2025-08-29T00:36:15.675137Z"
+     "iopub.execute_input": "2025-08-29T17:53:56.120391Z",
+     "iopub.status.busy": "2025-08-29T17:53:56.120099Z",
+     "iopub.status.idle": "2025-08-29T17:53:56.136094Z",
+     "shell.execute_reply": "2025-08-29T17:53:56.135529Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:56.120371Z"
     }
    },
    "outputs": [
@@ -269,10 +275,11 @@
    "id": "8a890b93-78ec-4681-bbb5-cc91e1448a85",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:15.676893Z",
-     "iopub.status.busy": "2025-08-29T00:36:15.676696Z",
-     "iopub.status.idle": "2025-08-29T00:36:15.679792Z",
-     "shell.execute_reply": "2025-08-29T00:36:15.679286Z"
+     "iopub.execute_input": "2025-08-29T17:53:56.137311Z",
+     "iopub.status.busy": "2025-08-29T17:53:56.136950Z",
+     "iopub.status.idle": "2025-08-29T17:53:56.144758Z",
+     "shell.execute_reply": "2025-08-29T17:53:56.144097Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:56.137281Z"
     }
    },
    "outputs": [],
@@ -289,10 +296,11 @@
    "id": "1dd17123-2df8-45b6-9345-d5cb6f431d51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:15.681190Z",
-     "iopub.status.busy": "2025-08-29T00:36:15.681030Z",
-     "iopub.status.idle": "2025-08-29T00:36:15.725608Z",
-     "shell.execute_reply": "2025-08-29T00:36:15.725072Z"
+     "iopub.execute_input": "2025-08-29T17:53:56.145772Z",
+     "iopub.status.busy": "2025-08-29T17:53:56.145513Z",
+     "iopub.status.idle": "2025-08-29T17:53:56.203970Z",
+     "shell.execute_reply": "2025-08-29T17:53:56.203038Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:56.145745Z"
     }
    },
    "outputs": [],
@@ -306,10 +314,11 @@
    "id": "b4c9ad67-47fe-4408-b879-d99b8eec8ca2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:15.727274Z",
-     "iopub.status.busy": "2025-08-29T00:36:15.727103Z",
-     "iopub.status.idle": "2025-08-29T00:36:15.730049Z",
-     "shell.execute_reply": "2025-08-29T00:36:15.729538Z"
+     "iopub.execute_input": "2025-08-29T17:53:56.205445Z",
+     "iopub.status.busy": "2025-08-29T17:53:56.204821Z",
+     "iopub.status.idle": "2025-08-29T17:53:56.208884Z",
+     "shell.execute_reply": "2025-08-29T17:53:56.208148Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:56.205422Z"
     }
    },
    "outputs": [],
@@ -326,10 +335,11 @@
    "id": "ffc07711-d8e3-49cf-9574-f2bde45ceec8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:15.731563Z",
-     "iopub.status.busy": "2025-08-29T00:36:15.731261Z",
-     "iopub.status.idle": "2025-08-29T00:36:15.736751Z",
-     "shell.execute_reply": "2025-08-29T00:36:15.736227Z"
+     "iopub.execute_input": "2025-08-29T17:53:56.210033Z",
+     "iopub.status.busy": "2025-08-29T17:53:56.209713Z",
+     "iopub.status.idle": "2025-08-29T17:53:56.220701Z",
+     "shell.execute_reply": "2025-08-29T17:53:56.220072Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:56.210004Z"
     }
    },
    "outputs": [
@@ -357,17 +367,18 @@
    "id": "0b89b688-a595-4ff3-81e3-8bba4d4ef7c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:15.738258Z",
-     "iopub.status.busy": "2025-08-29T00:36:15.738091Z",
-     "iopub.status.idle": "2025-08-29T00:36:15.877500Z",
-     "shell.execute_reply": "2025-08-29T00:36:15.877065Z"
+     "iopub.execute_input": "2025-08-29T17:53:56.221967Z",
+     "iopub.status.busy": "2025-08-29T17:53:56.221485Z",
+     "iopub.status.idle": "2025-08-29T17:53:56.381441Z",
+     "shell.execute_reply": "2025-08-29T17:53:56.380997Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:56.221945Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(<matplotlib.collections.QuadMesh at 0x7fef2d879d10>,)"
+       "(<matplotlib.collections.QuadMesh at 0x7f8f9fb39d10>,)"
       ]
      },
      "execution_count": 11,
@@ -395,10 +406,11 @@
    "id": "ff50fbfa-9dd4-4c01-a8eb-245c3c0706a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:15.879390Z",
-     "iopub.status.busy": "2025-08-29T00:36:15.879218Z",
-     "iopub.status.idle": "2025-08-29T00:36:19.641439Z",
-     "shell.execute_reply": "2025-08-29T00:36:19.640838Z"
+     "iopub.execute_input": "2025-08-29T17:53:56.382150Z",
+     "iopub.status.busy": "2025-08-29T17:53:56.381964Z",
+     "iopub.status.idle": "2025-08-29T17:54:00.200446Z",
+     "shell.execute_reply": "2025-08-29T17:54:00.199860Z",
+     "shell.execute_reply.started": "2025-08-29T17:53:56.382132Z"
     }
    },
    "outputs": [],
@@ -412,10 +424,11 @@
    "id": "094b1d30-c610-44ca-968b-7257aacbaa91",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:19.644148Z",
-     "iopub.status.busy": "2025-08-29T00:36:19.643876Z",
-     "iopub.status.idle": "2025-08-29T00:36:19.796321Z",
-     "shell.execute_reply": "2025-08-29T00:36:19.795805Z"
+     "iopub.execute_input": "2025-08-29T17:54:00.201463Z",
+     "iopub.status.busy": "2025-08-29T17:54:00.201234Z",
+     "iopub.status.idle": "2025-08-29T17:54:00.359588Z",
+     "shell.execute_reply": "2025-08-29T17:54:00.359016Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:00.201440Z"
     }
    },
    "outputs": [
@@ -459,10 +472,11 @@
    "id": "a4303772-cfe0-45ed-90ec-c1caad768f39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:19.798043Z",
-     "iopub.status.busy": "2025-08-29T00:36:19.797786Z",
-     "iopub.status.idle": "2025-08-29T00:36:19.800471Z",
-     "shell.execute_reply": "2025-08-29T00:36:19.799942Z"
+     "iopub.execute_input": "2025-08-29T17:54:00.360376Z",
+     "iopub.status.busy": "2025-08-29T17:54:00.360176Z",
+     "iopub.status.idle": "2025-08-29T17:54:00.363562Z",
+     "shell.execute_reply": "2025-08-29T17:54:00.362825Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:00.360359Z"
     }
    },
    "outputs": [],
@@ -476,10 +490,11 @@
    "id": "956f31ab-ed45-432f-a788-15cf73febf14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:19.802106Z",
-     "iopub.status.busy": "2025-08-29T00:36:19.801890Z",
-     "iopub.status.idle": "2025-08-29T00:36:19.813739Z",
-     "shell.execute_reply": "2025-08-29T00:36:19.813214Z"
+     "iopub.execute_input": "2025-08-29T17:54:00.364474Z",
+     "iopub.status.busy": "2025-08-29T17:54:00.364187Z",
+     "iopub.status.idle": "2025-08-29T17:54:00.392269Z",
+     "shell.execute_reply": "2025-08-29T17:54:00.391331Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:00.364448Z"
     }
    },
    "outputs": [],
@@ -493,10 +508,11 @@
    "id": "fd1dfb8c-fe88-4a46-b59e-70baaec550f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:19.816775Z",
-     "iopub.status.busy": "2025-08-29T00:36:19.816003Z",
-     "iopub.status.idle": "2025-08-29T00:36:19.968565Z",
-     "shell.execute_reply": "2025-08-29T00:36:19.967958Z"
+     "iopub.execute_input": "2025-08-29T17:54:00.394680Z",
+     "iopub.status.busy": "2025-08-29T17:54:00.394388Z",
+     "iopub.status.idle": "2025-08-29T17:54:00.549183Z",
+     "shell.execute_reply": "2025-08-29T17:54:00.548591Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:00.394652Z"
     }
    },
    "outputs": [
@@ -524,10 +540,11 @@
    "id": "e916f176-b4b7-427a-847c-a282f85640a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:19.970586Z",
-     "iopub.status.busy": "2025-08-29T00:36:19.970358Z",
-     "iopub.status.idle": "2025-08-29T00:36:20.454631Z",
-     "shell.execute_reply": "2025-08-29T00:36:20.454053Z"
+     "iopub.execute_input": "2025-08-29T17:54:00.550122Z",
+     "iopub.status.busy": "2025-08-29T17:54:00.549832Z",
+     "iopub.status.idle": "2025-08-29T17:54:01.046460Z",
+     "shell.execute_reply": "2025-08-29T17:54:01.045836Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:00.550095Z"
     }
    },
    "outputs": [
@@ -565,10 +582,11 @@
    "id": "c862c062-c7e2-4d7b-8825-109fa7072bdd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:20.456521Z",
-     "iopub.status.busy": "2025-08-29T00:36:20.456346Z",
-     "iopub.status.idle": "2025-08-29T00:36:20.458962Z",
-     "shell.execute_reply": "2025-08-29T00:36:20.458553Z"
+     "iopub.execute_input": "2025-08-29T17:54:01.047370Z",
+     "iopub.status.busy": "2025-08-29T17:54:01.047073Z",
+     "iopub.status.idle": "2025-08-29T17:54:01.050633Z",
+     "shell.execute_reply": "2025-08-29T17:54:01.050014Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:01.047351Z"
     }
    },
    "outputs": [],
@@ -583,10 +601,11 @@
    "id": "9042f903-4d02-4abe-9de1-2dfacfb3b3a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:20.460861Z",
-     "iopub.status.busy": "2025-08-29T00:36:20.460667Z",
-     "iopub.status.idle": "2025-08-29T00:36:20.464675Z",
-     "shell.execute_reply": "2025-08-29T00:36:20.464299Z"
+     "iopub.execute_input": "2025-08-29T17:54:01.051492Z",
+     "iopub.status.busy": "2025-08-29T17:54:01.051288Z",
+     "iopub.status.idle": "2025-08-29T17:54:01.068402Z",
+     "shell.execute_reply": "2025-08-29T17:54:01.067656Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:01.051473Z"
     }
    },
    "outputs": [],
@@ -604,10 +623,11 @@
    "id": "ae115d7f-6b08-4c4e-b5f3-7277c24a49e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:20.466403Z",
-     "iopub.status.busy": "2025-08-29T00:36:20.466181Z",
-     "iopub.status.idle": "2025-08-29T00:36:20.468960Z",
-     "shell.execute_reply": "2025-08-29T00:36:20.468448Z"
+     "iopub.execute_input": "2025-08-29T17:54:01.069912Z",
+     "iopub.status.busy": "2025-08-29T17:54:01.069538Z",
+     "iopub.status.idle": "2025-08-29T17:54:01.075287Z",
+     "shell.execute_reply": "2025-08-29T17:54:01.074550Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:01.069878Z"
     }
    },
    "outputs": [],
@@ -621,10 +641,11 @@
    "id": "dbc4da3d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:20.470540Z",
-     "iopub.status.busy": "2025-08-29T00:36:20.470180Z",
-     "iopub.status.idle": "2025-08-29T00:36:20.472688Z",
-     "shell.execute_reply": "2025-08-29T00:36:20.472188Z"
+     "iopub.execute_input": "2025-08-29T17:54:01.078670Z",
+     "iopub.status.busy": "2025-08-29T17:54:01.078460Z",
+     "iopub.status.idle": "2025-08-29T17:54:01.084570Z",
+     "shell.execute_reply": "2025-08-29T17:54:01.083803Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:01.078651Z"
     }
    },
    "outputs": [],
@@ -638,10 +659,11 @@
    "id": "463b4e7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:20.474112Z",
-     "iopub.status.busy": "2025-08-29T00:36:20.473948Z",
-     "iopub.status.idle": "2025-08-29T00:36:21.079494Z",
-     "shell.execute_reply": "2025-08-29T00:36:21.078968Z"
+     "iopub.execute_input": "2025-08-29T17:54:01.085595Z",
+     "iopub.status.busy": "2025-08-29T17:54:01.085269Z",
+     "iopub.status.idle": "2025-08-29T17:54:01.693402Z",
+     "shell.execute_reply": "2025-08-29T17:54:01.692748Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:01.085565Z"
     }
    },
    "outputs": [
@@ -658,7 +680,7 @@
     }
    ],
    "source": [
-    "preconditioner = ii.utils.get_jacobi_preconditioner(phi, initial_model)\n",
+    "preconditioner = ii.get_jacobi_preconditioner(phi, initial_model)\n",
     "preconditioner"
    ]
   },
@@ -668,10 +690,11 @@
    "id": "9bfe71bd-5dae-4eea-91ad-543d80596363",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:21.080913Z",
-     "iopub.status.busy": "2025-08-29T00:36:21.080744Z",
-     "iopub.status.idle": "2025-08-29T00:36:21.083256Z",
-     "shell.execute_reply": "2025-08-29T00:36:21.082759Z"
+     "iopub.execute_input": "2025-08-29T17:54:01.694266Z",
+     "iopub.status.busy": "2025-08-29T17:54:01.694061Z",
+     "iopub.status.idle": "2025-08-29T17:54:01.697310Z",
+     "shell.execute_reply": "2025-08-29T17:54:01.696682Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:01.694247Z"
     }
    },
    "outputs": [],
@@ -685,10 +708,11 @@
    "id": "e2dfb4e8-1996-4f3f-8b05-781fc2d4537c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:21.084665Z",
-     "iopub.status.busy": "2025-08-29T00:36:21.084442Z",
-     "iopub.status.idle": "2025-08-29T00:36:53.279453Z",
-     "shell.execute_reply": "2025-08-29T00:36:53.278864Z"
+     "iopub.execute_input": "2025-08-29T17:54:01.698087Z",
+     "iopub.status.busy": "2025-08-29T17:54:01.697884Z",
+     "iopub.status.idle": "2025-08-29T17:54:33.633691Z",
+     "shell.execute_reply": "2025-08-29T17:54:33.633075Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:01.698068Z"
     }
    },
    "outputs": [
@@ -696,7 +720,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Elapsed time (no preconditioner): 32.19s\n"
+      "Elapsed time (no preconditioner): 31.93s\n"
      ]
     }
    ],
@@ -715,10 +739,11 @@
    "id": "ec0c3ef3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:36:53.281877Z",
-     "iopub.status.busy": "2025-08-29T00:36:53.281422Z",
-     "iopub.status.idle": "2025-08-29T00:37:02.940193Z",
-     "shell.execute_reply": "2025-08-29T00:37:02.939588Z"
+     "iopub.execute_input": "2025-08-29T17:54:33.635172Z",
+     "iopub.status.busy": "2025-08-29T17:54:33.634656Z",
+     "iopub.status.idle": "2025-08-29T17:54:43.291262Z",
+     "shell.execute_reply": "2025-08-29T17:54:43.278655Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:33.635144Z"
     }
    },
    "outputs": [
@@ -726,7 +751,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Elapsed time (w/ preconditioner): 9.65s\n"
+      "Elapsed time (w/ preconditioner): 9.64s\n"
      ]
     }
    ],
@@ -743,10 +768,11 @@
    "id": "82c1ddc2-d886-4cd1-a42d-1c32af5d4465",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:02.942609Z",
-     "iopub.status.busy": "2025-08-29T00:37:02.942153Z",
-     "iopub.status.idle": "2025-08-29T00:37:02.946598Z",
-     "shell.execute_reply": "2025-08-29T00:37:02.946053Z"
+     "iopub.execute_input": "2025-08-29T17:54:43.292587Z",
+     "iopub.status.busy": "2025-08-29T17:54:43.292152Z",
+     "iopub.status.idle": "2025-08-29T17:54:43.311418Z",
+     "shell.execute_reply": "2025-08-29T17:54:43.310659Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:43.292559Z"
     }
    },
    "outputs": [
@@ -772,17 +798,18 @@
    "id": "70b2b5ea-d6dd-4cf3-855c-9e8fd600c7cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:02.948840Z",
-     "iopub.status.busy": "2025-08-29T00:37:02.948413Z",
-     "iopub.status.idle": "2025-08-29T00:37:03.091747Z",
-     "shell.execute_reply": "2025-08-29T00:37:03.091155Z"
+     "iopub.execute_input": "2025-08-29T17:54:43.312231Z",
+     "iopub.status.busy": "2025-08-29T17:54:43.311985Z",
+     "iopub.status.idle": "2025-08-29T17:54:43.461493Z",
+     "shell.execute_reply": "2025-08-29T17:54:43.460924Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:43.312205Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(<matplotlib.collections.QuadMesh at 0x7fef2db07b10>,)"
+       "(<matplotlib.collections.QuadMesh at 0x7f8fae1efb10>,)"
       ]
      },
      "execution_count": 27,
@@ -818,10 +845,11 @@
    "id": "5b2bad7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:03.093292Z",
-     "iopub.status.busy": "2025-08-29T00:37:03.093120Z",
-     "iopub.status.idle": "2025-08-29T00:37:03.097368Z",
-     "shell.execute_reply": "2025-08-29T00:37:03.096837Z"
+     "iopub.execute_input": "2025-08-29T17:54:43.462308Z",
+     "iopub.status.busy": "2025-08-29T17:54:43.462085Z",
+     "iopub.status.idle": "2025-08-29T17:54:43.467176Z",
+     "shell.execute_reply": "2025-08-29T17:54:43.466529Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:43.462291Z"
     }
    },
    "outputs": [
@@ -853,10 +881,11 @@
    "id": "c2f9a98a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:03.098881Z",
-     "iopub.status.busy": "2025-08-29T00:37:03.098718Z",
-     "iopub.status.idle": "2025-08-29T00:37:03.102366Z",
-     "shell.execute_reply": "2025-08-29T00:37:03.101849Z"
+     "iopub.execute_input": "2025-08-29T17:54:43.468156Z",
+     "iopub.status.busy": "2025-08-29T17:54:43.467908Z",
+     "iopub.status.idle": "2025-08-29T17:54:43.482261Z",
+     "shell.execute_reply": "2025-08-29T17:54:43.481657Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:43.468138Z"
     }
    },
    "outputs": [],
@@ -874,6 +903,9 @@
     "# Beta cooling\n",
     "beta_cooler = ii.MultiplierCooler(regularization, cooling_factor=2.0)\n",
     "\n",
+    "# Preconditioner (a dynamic one that will update itself on every iteration)\n",
+    "preconditioner = ii.JacobiPreconditioner(phi)\n",
+    "\n",
     "# Inversion\n",
     "inversion = ii.Inversion(\n",
     "    phi,\n",
@@ -882,7 +914,7 @@
     "    directives=[beta_cooler],\n",
     "    stopping_criteria=stopping_criteria,\n",
     "    cache_models=True,\n",
-    "    preconditioner=lambda model: ii.utils.get_jacobi_preconditioner(phi, model),\n",
+    "    preconditioner=preconditioner,\n",
     ")"
    ]
   },
@@ -892,17 +924,18 @@
    "id": "e8b52457-d02e-44d6-a3f4-6038e4be9969",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:03.103853Z",
-     "iopub.status.busy": "2025-08-29T00:37:03.103690Z",
-     "iopub.status.idle": "2025-08-29T00:37:03.106954Z",
-     "shell.execute_reply": "2025-08-29T00:37:03.106539Z"
+     "iopub.execute_input": "2025-08-29T17:54:43.482972Z",
+     "iopub.status.busy": "2025-08-29T17:54:43.482780Z",
+     "iopub.status.idle": "2025-08-29T17:54:43.492323Z",
+     "shell.execute_reply": "2025-08-29T17:54:43.491548Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:43.482955Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<inversion_ideas.inversion_log.InversionLogRich at 0x7fef2db374d0>"
+       "<inversion_ideas.inversion_log.InversionLogRich at 0x7f8fae25fcb0>"
       ]
      },
      "execution_count": 30,
@@ -921,17 +954,18 @@
    "id": "92ab4716",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:03.108367Z",
-     "iopub.status.busy": "2025-08-29T00:37:03.108208Z",
-     "iopub.status.idle": "2025-08-29T00:37:19.531237Z",
-     "shell.execute_reply": "2025-08-29T00:37:19.530728Z"
+     "iopub.execute_input": "2025-08-29T17:54:43.493456Z",
+     "iopub.status.busy": "2025-08-29T17:54:43.493136Z",
+     "iopub.status.idle": "2025-08-29T17:55:02.203752Z",
+     "shell.execute_reply": "2025-08-29T17:55:02.202929Z",
+     "shell.execute_reply.started": "2025-08-29T17:54:43.493434Z"
     }
    },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "40454e8f8a70440db4cfcb8f565947ad",
+       "model_id": "a89151025ee84100ad4e790d5e05edb9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -981,10 +1015,11 @@
    "id": "15a9a4ca-c6b5-443c-8d9b-22c4bd883f1b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:19.700171Z",
-     "iopub.status.busy": "2025-08-29T00:37:19.700014Z",
-     "iopub.status.idle": "2025-08-29T00:37:19.707279Z",
-     "shell.execute_reply": "2025-08-29T00:37:19.706888Z"
+     "iopub.execute_input": "2025-08-29T17:55:02.205106Z",
+     "iopub.status.busy": "2025-08-29T17:55:02.204685Z",
+     "iopub.status.idle": "2025-08-29T17:55:02.225263Z",
+     "shell.execute_reply": "2025-08-29T17:55:02.224654Z",
+     "shell.execute_reply.started": "2025-08-29T17:55:02.205079Z"
     }
    },
    "outputs": [
@@ -1029,10 +1064,11 @@
    "id": "519f2172",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:19.708954Z",
-     "iopub.status.busy": "2025-08-29T00:37:19.708791Z",
-     "iopub.status.idle": "2025-08-29T00:37:19.718775Z",
-     "shell.execute_reply": "2025-08-29T00:37:19.718270Z"
+     "iopub.execute_input": "2025-08-29T17:55:02.226303Z",
+     "iopub.status.busy": "2025-08-29T17:55:02.225998Z",
+     "iopub.status.idle": "2025-08-29T17:55:02.254140Z",
+     "shell.execute_reply": "2025-08-29T17:55:02.253385Z",
+     "shell.execute_reply.started": "2025-08-29T17:55:02.226277Z"
     }
    },
    "outputs": [
@@ -1165,10 +1201,11 @@
    "id": "c941b221",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:19.720551Z",
-     "iopub.status.busy": "2025-08-29T00:37:19.720373Z",
-     "iopub.status.idle": "2025-08-29T00:37:20.391482Z",
-     "shell.execute_reply": "2025-08-29T00:37:20.390965Z"
+     "iopub.execute_input": "2025-08-29T17:55:02.255337Z",
+     "iopub.status.busy": "2025-08-29T17:55:02.255054Z",
+     "iopub.status.idle": "2025-08-29T17:55:03.035029Z",
+     "shell.execute_reply": "2025-08-29T17:55:03.034091Z",
+     "shell.execute_reply.started": "2025-08-29T17:55:02.255310Z"
     }
    },
    "outputs": [
@@ -1205,10 +1242,11 @@
    "id": "8dbf6693",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:20.393269Z",
-     "iopub.status.busy": "2025-08-29T00:37:20.393104Z",
-     "iopub.status.idle": "2025-08-29T00:37:21.086625Z",
-     "shell.execute_reply": "2025-08-29T00:37:21.086116Z"
+     "iopub.execute_input": "2025-08-29T17:55:03.035973Z",
+     "iopub.status.busy": "2025-08-29T17:55:03.035708Z",
+     "iopub.status.idle": "2025-08-29T17:55:03.890235Z",
+     "shell.execute_reply": "2025-08-29T17:55:03.889602Z",
+     "shell.execute_reply.started": "2025-08-29T17:55:03.035955Z"
     }
    },
    "outputs": [
@@ -1277,10 +1315,11 @@
    "id": "49c895ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:21.088254Z",
-     "iopub.status.busy": "2025-08-29T00:37:21.088079Z",
-     "iopub.status.idle": "2025-08-29T00:37:22.438391Z",
-     "shell.execute_reply": "2025-08-29T00:37:22.437856Z"
+     "iopub.execute_input": "2025-08-29T17:55:03.891024Z",
+     "iopub.status.busy": "2025-08-29T17:55:03.890768Z",
+     "iopub.status.idle": "2025-08-29T17:55:05.211930Z",
+     "shell.execute_reply": "2025-08-29T17:55:05.211359Z",
+     "shell.execute_reply.started": "2025-08-29T17:55:03.891001Z"
     }
    },
    "outputs": [

--- a/notebooks/12_gravity-inversion-with-constructor.ipynb
+++ b/notebooks/12_gravity-inversion-with-constructor.ipynb
@@ -14,10 +14,11 @@
    "id": "b2d27e8b-5b33-4361-990b-8b6e724f5ac6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:24.313178Z",
-     "iopub.status.busy": "2025-08-29T00:37:24.312460Z",
-     "iopub.status.idle": "2025-08-29T00:37:25.871483Z",
-     "shell.execute_reply": "2025-08-29T00:37:25.870884Z"
+     "iopub.execute_input": "2025-08-29T18:04:24.279497Z",
+     "iopub.status.busy": "2025-08-29T18:04:24.278066Z",
+     "iopub.status.idle": "2025-08-29T18:04:25.965462Z",
+     "shell.execute_reply": "2025-08-29T18:04:25.964852Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:24.279448Z"
     }
    },
    "outputs": [],
@@ -54,10 +55,11 @@
    "id": "dfce90d3-de10-43d3-a668-696993b0f73e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:25.873440Z",
-     "iopub.status.busy": "2025-08-29T00:37:25.873126Z",
-     "iopub.status.idle": "2025-08-29T00:37:25.876676Z",
-     "shell.execute_reply": "2025-08-29T00:37:25.876305Z"
+     "iopub.execute_input": "2025-08-29T18:04:25.966306Z",
+     "iopub.status.busy": "2025-08-29T18:04:25.965970Z",
+     "iopub.status.idle": "2025-08-29T18:04:25.970328Z",
+     "shell.execute_reply": "2025-08-29T18:04:25.969676Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:25.966288Z"
     }
    },
    "outputs": [],
@@ -80,10 +82,11 @@
    "id": "0edbb620-6a62-48bf-a8af-8981a76cc6f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:25.878147Z",
-     "iopub.status.busy": "2025-08-29T00:37:25.877979Z",
-     "iopub.status.idle": "2025-08-29T00:37:25.883966Z",
-     "shell.execute_reply": "2025-08-29T00:37:25.883454Z"
+     "iopub.execute_input": "2025-08-29T18:04:25.971256Z",
+     "iopub.status.busy": "2025-08-29T18:04:25.971010Z",
+     "iopub.status.idle": "2025-08-29T18:04:25.989875Z",
+     "shell.execute_reply": "2025-08-29T18:04:25.989215Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:25.971236Z"
     }
    },
    "outputs": [
@@ -169,10 +172,11 @@
    "id": "8a890b93-78ec-4681-bbb5-cc91e1448a85",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:25.885409Z",
-     "iopub.status.busy": "2025-08-29T00:37:25.885243Z",
-     "iopub.status.idle": "2025-08-29T00:37:25.888326Z",
-     "shell.execute_reply": "2025-08-29T00:37:25.887904Z"
+     "iopub.execute_input": "2025-08-29T18:04:25.990627Z",
+     "iopub.status.busy": "2025-08-29T18:04:25.990424Z",
+     "iopub.status.idle": "2025-08-29T18:04:25.996615Z",
+     "shell.execute_reply": "2025-08-29T18:04:25.995823Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:25.990609Z"
     }
    },
    "outputs": [],
@@ -189,10 +193,11 @@
    "id": "1dd17123-2df8-45b6-9345-d5cb6f431d51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:25.889782Z",
-     "iopub.status.busy": "2025-08-29T00:37:25.889586Z",
-     "iopub.status.idle": "2025-08-29T00:37:25.934976Z",
-     "shell.execute_reply": "2025-08-29T00:37:25.934514Z"
+     "iopub.execute_input": "2025-08-29T18:04:25.998084Z",
+     "iopub.status.busy": "2025-08-29T18:04:25.997586Z",
+     "iopub.status.idle": "2025-08-29T18:04:26.055719Z",
+     "shell.execute_reply": "2025-08-29T18:04:26.055081Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:25.998052Z"
     }
    },
    "outputs": [],
@@ -206,10 +211,11 @@
    "id": "b4c9ad67-47fe-4408-b879-d99b8eec8ca2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:25.936642Z",
-     "iopub.status.busy": "2025-08-29T00:37:25.936477Z",
-     "iopub.status.idle": "2025-08-29T00:37:25.939409Z",
-     "shell.execute_reply": "2025-08-29T00:37:25.938944Z"
+     "iopub.execute_input": "2025-08-29T18:04:26.057615Z",
+     "iopub.status.busy": "2025-08-29T18:04:26.057387Z",
+     "iopub.status.idle": "2025-08-29T18:04:26.061394Z",
+     "shell.execute_reply": "2025-08-29T18:04:26.060806Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:26.057595Z"
     }
    },
    "outputs": [],
@@ -226,10 +232,11 @@
    "id": "ffc07711-d8e3-49cf-9574-f2bde45ceec8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:25.941093Z",
-     "iopub.status.busy": "2025-08-29T00:37:25.940751Z",
-     "iopub.status.idle": "2025-08-29T00:37:25.946148Z",
-     "shell.execute_reply": "2025-08-29T00:37:25.945622Z"
+     "iopub.execute_input": "2025-08-29T18:04:26.062091Z",
+     "iopub.status.busy": "2025-08-29T18:04:26.061888Z",
+     "iopub.status.idle": "2025-08-29T18:04:26.073753Z",
+     "shell.execute_reply": "2025-08-29T18:04:26.073037Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:26.062072Z"
     }
    },
    "outputs": [
@@ -257,17 +264,18 @@
    "id": "0b89b688-a595-4ff3-81e3-8bba4d4ef7c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:25.947694Z",
-     "iopub.status.busy": "2025-08-29T00:37:25.947491Z",
-     "iopub.status.idle": "2025-08-29T00:37:26.117215Z",
-     "shell.execute_reply": "2025-08-29T00:37:26.116697Z"
+     "iopub.execute_input": "2025-08-29T18:04:26.074957Z",
+     "iopub.status.busy": "2025-08-29T18:04:26.074643Z",
+     "iopub.status.idle": "2025-08-29T18:04:26.269247Z",
+     "shell.execute_reply": "2025-08-29T18:04:26.268686Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:26.074929Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(<matplotlib.collections.QuadMesh at 0x7fe8a6e4a900>,)"
+       "(<matplotlib.collections.QuadMesh at 0x7fd4e5eb5010>,)"
       ]
      },
      "execution_count": 8,
@@ -295,10 +303,11 @@
    "id": "2403d600-451e-424e-8de9-3f824f1e2647",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:26.119168Z",
-     "iopub.status.busy": "2025-08-29T00:37:26.118699Z",
-     "iopub.status.idle": "2025-08-29T00:37:29.957365Z",
-     "shell.execute_reply": "2025-08-29T00:37:29.956835Z"
+     "iopub.execute_input": "2025-08-29T18:04:26.270001Z",
+     "iopub.status.busy": "2025-08-29T18:04:26.269808Z",
+     "iopub.status.idle": "2025-08-29T18:04:30.569934Z",
+     "shell.execute_reply": "2025-08-29T18:04:30.569317Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:26.269983Z"
     }
    },
    "outputs": [
@@ -326,10 +335,11 @@
    "id": "094b1d30-c610-44ca-968b-7257aacbaa91",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:29.959244Z",
-     "iopub.status.busy": "2025-08-29T00:37:29.959029Z",
-     "iopub.status.idle": "2025-08-29T00:37:30.129403Z",
-     "shell.execute_reply": "2025-08-29T00:37:30.128880Z"
+     "iopub.execute_input": "2025-08-29T18:04:30.573341Z",
+     "iopub.status.busy": "2025-08-29T18:04:30.572028Z",
+     "iopub.status.idle": "2025-08-29T18:04:30.733008Z",
+     "shell.execute_reply": "2025-08-29T18:04:30.732335Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:30.573306Z"
     }
    },
    "outputs": [
@@ -373,10 +383,11 @@
    "id": "a4303772-cfe0-45ed-90ec-c1caad768f39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:30.131056Z",
-     "iopub.status.busy": "2025-08-29T00:37:30.130884Z",
-     "iopub.status.idle": "2025-08-29T00:37:30.133476Z",
-     "shell.execute_reply": "2025-08-29T00:37:30.133122Z"
+     "iopub.execute_input": "2025-08-29T18:04:30.734082Z",
+     "iopub.status.busy": "2025-08-29T18:04:30.733667Z",
+     "iopub.status.idle": "2025-08-29T18:04:30.737382Z",
+     "shell.execute_reply": "2025-08-29T18:04:30.736763Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:30.734058Z"
     }
    },
    "outputs": [],
@@ -390,10 +401,11 @@
    "id": "c862c062-c7e2-4d7b-8825-109fa7072bdd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:30.134882Z",
-     "iopub.status.busy": "2025-08-29T00:37:30.134719Z",
-     "iopub.status.idle": "2025-08-29T00:37:30.137292Z",
-     "shell.execute_reply": "2025-08-29T00:37:30.136936Z"
+     "iopub.execute_input": "2025-08-29T18:04:30.738724Z",
+     "iopub.status.busy": "2025-08-29T18:04:30.738135Z",
+     "iopub.status.idle": "2025-08-29T18:04:30.752974Z",
+     "shell.execute_reply": "2025-08-29T18:04:30.752048Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:30.738692Z"
     }
    },
    "outputs": [],
@@ -416,10 +428,11 @@
    "id": "9042f903-4d02-4abe-9de1-2dfacfb3b3a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:30.138939Z",
-     "iopub.status.busy": "2025-08-29T00:37:30.138651Z",
-     "iopub.status.idle": "2025-08-29T00:37:30.142897Z",
-     "shell.execute_reply": "2025-08-29T00:37:30.142364Z"
+     "iopub.execute_input": "2025-08-29T18:04:30.753917Z",
+     "iopub.status.busy": "2025-08-29T18:04:30.753605Z",
+     "iopub.status.idle": "2025-08-29T18:04:30.765802Z",
+     "shell.execute_reply": "2025-08-29T18:04:30.764426Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:30.753886Z"
     }
    },
    "outputs": [],
@@ -445,10 +458,11 @@
    "id": "a5b03530-fc32-49aa-8799-7ea4403dcd11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:30.144492Z",
-     "iopub.status.busy": "2025-08-29T00:37:30.144326Z",
-     "iopub.status.idle": "2025-08-29T00:37:30.147888Z",
-     "shell.execute_reply": "2025-08-29T00:37:30.147402Z"
+     "iopub.execute_input": "2025-08-29T18:04:30.768240Z",
+     "iopub.status.busy": "2025-08-29T18:04:30.767204Z",
+     "iopub.status.idle": "2025-08-29T18:04:30.773909Z",
+     "shell.execute_reply": "2025-08-29T18:04:30.772900Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:30.768180Z"
     }
    },
    "outputs": [],
@@ -463,6 +477,7 @@
     "    starting_beta=1e4,\n",
     "    initial_model=initial_model,\n",
     "    minimizer=minimizer,\n",
+    "    preconditioner=\"jacobi\",\n",
     ")"
    ]
   },
@@ -472,10 +487,11 @@
    "id": "ec0c3ef3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:30.149457Z",
-     "iopub.status.busy": "2025-08-29T00:37:30.149169Z",
-     "iopub.status.idle": "2025-08-29T00:37:47.291607Z",
-     "shell.execute_reply": "2025-08-29T00:37:47.291100Z"
+     "iopub.execute_input": "2025-08-29T18:04:30.776016Z",
+     "iopub.status.busy": "2025-08-29T18:04:30.774957Z",
+     "iopub.status.idle": "2025-08-29T18:04:49.489689Z",
+     "shell.execute_reply": "2025-08-29T18:04:49.489095Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:30.775962Z"
     },
     "scrolled": true
    },
@@ -483,7 +499,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c8ccb9e5aafa41f8a116e36623c11235",
+       "model_id": "7c09e553c3d4479397ade86774651f4e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -522,10 +538,11 @@
    "id": "4cd79386-3d2b-4e27-b7d3-6704d28c1a87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:47.465139Z",
-     "iopub.status.busy": "2025-08-29T00:37:47.464983Z",
-     "iopub.status.idle": "2025-08-29T00:37:47.488818Z",
-     "shell.execute_reply": "2025-08-29T00:37:47.488324Z"
+     "iopub.execute_input": "2025-08-29T18:04:49.493693Z",
+     "iopub.status.busy": "2025-08-29T18:04:49.492230Z",
+     "iopub.status.idle": "2025-08-29T18:04:49.535563Z",
+     "shell.execute_reply": "2025-08-29T18:04:49.534878Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:49.493659Z"
     }
    },
    "outputs": [
@@ -560,10 +577,11 @@
    "id": "44ef609b-fe1a-4f1d-bc11-6dcf60b156ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:47.491093Z",
-     "iopub.status.busy": "2025-08-29T00:37:47.490857Z",
-     "iopub.status.idle": "2025-08-29T00:37:47.503917Z",
-     "shell.execute_reply": "2025-08-29T00:37:47.503429Z"
+     "iopub.execute_input": "2025-08-29T18:04:49.539221Z",
+     "iopub.status.busy": "2025-08-29T18:04:49.537908Z",
+     "iopub.status.idle": "2025-08-29T18:04:49.567501Z",
+     "shell.execute_reply": "2025-08-29T18:04:49.566874Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:49.539192Z"
     }
    },
    "outputs": [
@@ -681,10 +699,11 @@
    "id": "9feec0e0-ce9b-43cf-b7e5-bc4f77ae879f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:47.506303Z",
-     "iopub.status.busy": "2025-08-29T00:37:47.506081Z",
-     "iopub.status.idle": "2025-08-29T00:37:48.300096Z",
-     "shell.execute_reply": "2025-08-29T00:37:48.299528Z"
+     "iopub.execute_input": "2025-08-29T18:04:49.570783Z",
+     "iopub.status.busy": "2025-08-29T18:04:49.569589Z",
+     "iopub.status.idle": "2025-08-29T18:04:50.402788Z",
+     "shell.execute_reply": "2025-08-29T18:04:50.402213Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:49.570756Z"
     }
    },
    "outputs": [
@@ -721,17 +740,18 @@
    "id": "70b2b5ea-d6dd-4cf3-855c-9e8fd600c7cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-29T00:37:48.301559Z",
-     "iopub.status.busy": "2025-08-29T00:37:48.301373Z",
-     "iopub.status.idle": "2025-08-29T00:37:48.425776Z",
-     "shell.execute_reply": "2025-08-29T00:37:48.425259Z"
+     "iopub.execute_input": "2025-08-29T18:04:50.403574Z",
+     "iopub.status.busy": "2025-08-29T18:04:50.403336Z",
+     "iopub.status.idle": "2025-08-29T18:04:50.565089Z",
+     "shell.execute_reply": "2025-08-29T18:04:50.564360Z",
+     "shell.execute_reply.started": "2025-08-29T18:04:50.403556Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(<matplotlib.collections.QuadMesh at 0x7fe88f62b750>,)"
+       "(<matplotlib.collections.QuadMesh at 0x7fd4ce6b3750>,)"
       ]
      },
      "execution_count": 19,

--- a/src/inversion_ideas/__init__.py
+++ b/src/inversion_ideas/__init__.py
@@ -12,6 +12,7 @@ from .errors import ConvergenceWarning
 from .inversion import Inversion
 from .inversion_log import InversionLog, InversionLogRich
 from .minimizers import ConjugateGradient
+from .preconditioners import JacobiPreconditioner, get_jacobi_preconditioner
 from .regularization import TikhonovZero
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "Inversion",
     "InversionLog",
     "InversionLogRich",
+    "JacobiPreconditioner",
     "ModelChanged",
     "MultiplierCooler",
     "ObjectiveChanged",
@@ -30,5 +32,6 @@ __all__ = [
     "__version__",
     "base",
     "create_inversion",
+    "get_jacobi_preconditioner",
     "utils",
 ]

--- a/src/inversion_ideas/constructors.py
+++ b/src/inversion_ideas/constructors.py
@@ -2,7 +2,6 @@
 Functions to easily build commonly used objects in inversions.
 """
 
-from collections.abc import Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -11,7 +10,7 @@ from .base import Minimizer, Objective
 from .conditions import ChiTarget
 from .directives import MultiplierCooler
 from .inversion import Inversion
-from .preconditioners import get_jacobi_preconditioner, JacobiPreconditioner
+from .preconditioners import JacobiPreconditioner
 
 
 def create_inversion(

--- a/src/inversion_ideas/constructors.py
+++ b/src/inversion_ideas/constructors.py
@@ -2,7 +2,6 @@
 Functions to easily build commonly used objects in inversions.
 """
 
-
 import numpy as np
 import numpy.typing as npt
 

--- a/src/inversion_ideas/constructors.py
+++ b/src/inversion_ideas/constructors.py
@@ -11,7 +11,7 @@ from .base import Minimizer, Objective
 from .conditions import ChiTarget
 from .directives import MultiplierCooler
 from .inversion import Inversion
-from .utils import get_jacobi_preconditioner
+from .preconditioners import get_jacobi_preconditioner, JacobiPreconditioner
 
 
 def create_inversion(
@@ -25,8 +25,7 @@ def create_inversion(
     beta_cooling_rate: int = 1,
     chi_target: float = 1.0,
     cache_models: bool = True,
-    preconditioner="jacobi",
-    update_preconditioner=True,
+    preconditioner=None,
 ) -> Inversion:
     r"""
     Create inversion of the form :math:`\phi_d + \beta \phi_m`.
@@ -56,11 +55,19 @@ def create_inversion(
         reaches a :math:`\chi` factor lower or equal to ``chi_target``.
     cache_models : bool, optional
         Whether to cache models after each iteration in the inversion.
+    preconditioner : {"jacobi"} or 2d array or sparray or LinearOperator or callable or None, optional
+        Preconditioner that will be passed to the ``minimizer`` on every call during the
+        inversion. The preconditioner can be a predefined 2d array, a sparse array or
+        a LinearOperator. Alternatively, it can be a callable that takes the ``model``
+        as argument and returns a preconditioner matrix (same types listed before). If
+        ``"jacobi"``, a default Jacobi preconditioner that will get updated on every
+        iteration will be defined for the inversion. If None, no preconditioner will be
+        passed.
 
     Returns
     -------
     Inversion
-    """
+    """  # noqa: E501
     # Define objective function
     regularization = starting_beta * model_norm
     objective_function = data_misfit + regularization
@@ -82,35 +89,10 @@ def create_inversion(
     if preconditioner is not None:
         if isinstance(preconditioner, str):
             if preconditioner == "jacobi":
-                if update_preconditioner:
-                    preconditioner = (  # noqa: E731
-                        lambda model: get_jacobi_preconditioner(
-                            objective_function, model
-                        )
-                    )
-                else:
-                    preconditioner = get_jacobi_preconditioner(
-                        objective_function, initial_model
-                    )
+                preconditioner = JacobiPreconditioner(objective_function)
             else:
                 msg = f"Invalid preconditioner '{preconditioner}'."
                 raise ValueError(msg)
-
-        if update_preconditioner and not isinstance(preconditioner, Callable):
-            msg = (
-                f"Invalid preconditioner '{preconditioner}'"
-                "When setting `update_preconditioner` to True, "
-                "the `preconditioner` should be a callable."
-            )
-            raise TypeError(msg)
-        if not update_preconditioner and isinstance(preconditioner, Callable):
-            msg = (
-                f"Invalid preconditioner '{preconditioner}'."
-                f"Cannot set `update_preconditioner` to False and pass "
-                "`preconditioner` as a Callable."
-            )
-            raise TypeError(msg)
-
         kwargs["preconditioner"] = preconditioner
 
     # Define inversion

--- a/src/inversion_ideas/preconditioners.py
+++ b/src/inversion_ideas/preconditioners.py
@@ -1,0 +1,87 @@
+"""
+Classes and functions to build preconditioners.
+"""
+import numpy as np
+import numpy.typing as npt
+from scipy.sparse import diags_array, sparray
+
+from .base import Objective
+
+
+class JacobiPreconditioner:
+    """
+    Jacobi preconditioner for a given objective function.
+
+    Use this class to define a dynamic Jacobi preconditioner from an objective function.
+    This class is a callable that will update the preconditioner for the given model
+    each time it gets called. Use this class if you want to update the preconditioner
+    on every iteration of the `Inversion`.
+
+    Parameters
+    ----------
+    objective_function : Objective
+        Objective function for which the Jacobi preconditioner will be built.
+
+    See also
+    --------
+    get_jacobi_preconditioner
+    """
+
+    def __init__(self, objective_function: Objective):
+        self.objective_function = objective_function
+
+    def __call__(self, model: npt.NDArray[np.float64]) -> sparray:
+        """
+        Generate a Jacobi preconditioner as a sparse diagonal array for a given model.
+
+        Parameters
+        ----------
+        model : (n_params) array
+            Model that will be used to build the Jacobi preconditioner from the
+            ``objective_function``.
+
+        Returns
+        -------
+        dia_array
+        """
+        return get_jacobi_preconditioner(self.objective_function, model)
+
+
+def get_jacobi_preconditioner(
+    objective_function: Objective, model: npt.NDArray[np.float64]
+):
+    r"""
+    Obtain a Jacobi preconditioner from an objective function.
+
+    Parameters
+    ----------
+    objective_function : Objective
+        Objective function from which the preconditioner will be built.
+    model : (n_params) array
+        Model used to build the preconditioner.
+
+    Returns
+    -------
+    diag_array
+        Preconditioner as a sparse diagonal array.
+
+    Notes
+    -----
+    Given an objective function :math:`\phi(\mathbf{m})`, this function builds the
+    Jacobi preconditioner :math:`\mathbf{P}(\mathbf{m})` as the inverse of the diagonal
+    of the Hessian of :math:`\phi(\mathbf{m})`:
+
+    .. math::
+
+        \mathbf{P}(\mathbf{m}) = \text{diag}[ \bar{\bar{\nabla}} \phi(\mathbf{m}) ]^{-1}
+
+    where :math:`\bar{\bar{\nabla}} \phi(\mathbf{m})` is the Hessian of
+    :math:`\phi(\mathbf{m})`.
+    """
+    hessian_diag = objective_function.hessian_diagonal(model)
+
+    # Compute inverse only for non-zero elements
+    zeros = hessian_diag == 0.0
+    hessian_diag[~zeros] **= -1
+
+    return diags_array(hessian_diag)

--- a/src/inversion_ideas/preconditioners.py
+++ b/src/inversion_ideas/preconditioners.py
@@ -1,6 +1,7 @@
 """
 Classes and functions to build preconditioners.
 """
+
 import numpy as np
 import numpy.typing as npt
 from scipy.sparse import diags_array, sparray

--- a/src/inversion_ideas/utils.py
+++ b/src/inversion_ideas/utils.py
@@ -6,7 +6,6 @@ import functools
 import hashlib
 import logging
 
-
 __all__ = [
     "cache_on_model",
     "get_logger",

--- a/src/inversion_ideas/utils.py
+++ b/src/inversion_ideas/utils.py
@@ -6,11 +6,6 @@ import functools
 import hashlib
 import logging
 
-import numpy as np
-import numpy.typing as npt
-from scipy.sparse import diags_array
-
-from .base import Objective
 
 __all__ = [
     "cache_on_model",
@@ -118,43 +113,3 @@ def cache_on_model(func):
         return result
 
     return wrapper
-
-
-def get_jacobi_preconditioner(
-    objective_function: Objective, model: npt.NDArray[np.float64]
-):
-    r"""
-    Obtain a Jacobi preconditioner from an objective function.
-
-    Parameters
-    ----------
-    objective_function : Objective
-        Objective function from which the preconditioner will be built.
-    model : (n_params) array
-        Model used to build the preconditioner.
-
-    Returns
-    -------
-    diag_array
-        Preconditioner as a sparse diagonal array.
-
-    Notes
-    -----
-    Given an objective function :math:`\phi(\mathbf{m})`, this function builds the
-    Jacobi preconditioner :math:`\mathbf{P}(\mathbf{m})` as the inverse of the diagonal
-    of the Hessian of :math:`\phi(\mathbf{m})`:
-
-    .. math::
-
-        \mathbf{P}(\mathbf{m}) = \text{diag}[ \bar{\bar{\nabla}} \phi(\mathbf{m}) ]^{-1}
-
-    where :math:`\bar{\bar{\nabla}} \phi(\mathbf{m})` is the Hessian of
-    :math:`\phi(\mathbf{m})`.
-    """
-    hessian_diag = objective_function.hessian_diagonal(model)
-
-    # Compute inverse only for non-zero elements
-    zeros = hessian_diag == 0.0
-    hessian_diag[~zeros] **= -1
-
-    return diags_array(hessian_diag)


### PR DESCRIPTION
The new class returns a callable object that can be used as preconditioner: it generates a Jacobi preconditioner for a given objective function. This class can be used to update the preconditioner on every iteration through an inversion. Create a new `preconditioner.py` file where the new class and the `get_jacobi_preconditioner` function live. Simplify the inversion constructor: Remove the `update_preconditioner` argument: if we pass `"jacobi"` as preconditioner, it'll define a `JacobiPreconditioner` that will get updated on each iteration. Users can easily define predefined preconditioners instead, no need to add complexity with another argument in the function. Update and rerun notebooks 11 and 12.
