### PR TITLE
Pin pymatsolver to v0.3.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - scipy
   - rich
   - simpeg==0.24
+  - pymatsolver==0.3.1  # need to pin it for simpeg v0.24.0
   - discretize==0.11
   # Required by notebooks
   - harmonica

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "scipy",
     "rich",
     "simpeg==0.24.0",
+    "pymatsolver==0.3.1",  # need to pin it for simpeg v0.24.0
     "discretize==0.11.3",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ mypy
 scipy-stubs
 discretize==0.11.3
 simpeg==0.24.0
+pymatsolver==0.3.1


### PR DESCRIPTION
The new pymatsolver v0.4.0 is not compatible with SimPEG v0.24.0.
