### PR TITLE
Fix logic with `counter` in `Inversion`

### DIFF
--- a/src/inversion_ideas/inversion.py
+++ b/src/inversion_ideas/inversion.py
@@ -92,7 +92,6 @@ class Inversion:
         """
         # Zeroth iteration
         if not hasattr(self, "_counter"):
-
             # Initialize counter to zero
             self._counter = 0
 


### PR DESCRIPTION
Fix bug introduced in the last commit. Now the counter is always set to the last iteration that was run. Before the zeroth iteration, the `Inversion` doesn't have any counter.
