### PR TITLE
Fix directives being called too soon

### DIFF
--- a/src/inversion_ideas/inversion.py
+++ b/src/inversion_ideas/inversion.py
@@ -132,7 +132,7 @@ class Inversion:
         # We update the directives here (and not at the end of this method), so after
         # each iteration the objective function is still the same we passed to the
         # minimizer.
-        if self.counter > 1:
+        if self._counter > 1:
             for directive in self.directives:
                 directive(self.model, self.counter)
 


### PR DESCRIPTION
Move the counter increase before the directives update, and only update directives when `counter > 1`: this way we don't run directives before the first minimization.
