### PR TITLE
Use the `Model` type alias everywhere in the library

### DIFF
--- a/src/inversion_ideas/base/directive.py
+++ b/src/inversion_ideas/base/directive.py
@@ -4,8 +4,7 @@ Base class for directives.
 
 from abc import ABC, abstractmethod
 
-import numpy as np
-import numpy.typing as npt
+from ..typing import Model
 
 
 class Directive(ABC):
@@ -14,5 +13,5 @@ class Directive(ABC):
     """
 
     @abstractmethod
-    def __call__(self, model: npt.NDArray[np.float64], iteration: int):
+    def __call__(self, model: Model, iteration: int):
         pass

--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -12,6 +12,8 @@ import numpy.typing as npt
 from scipy.sparse import sparray
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
+from ..typing import Model
+
 
 class Objective(ABC):
     """
@@ -34,20 +36,20 @@ class Objective(ABC):
         """
 
     @abstractmethod
-    def __call__(self, model: npt.NDArray) -> float:
+    def __call__(self, model: Model) -> float:
         """
         Evaluate the objective function for a given model.
         """
 
     @abstractmethod
-    def gradient(self, model: npt.NDArray) -> npt.NDArray[np.float64]:
+    def gradient(self, model: Model) -> npt.NDArray[np.float64]:
         """
         Evaluate the gradient of the objective function for a given model.
         """
 
     @abstractmethod
     def hessian(
-        self, model: npt.NDArray
+        self, model: Model
     ) -> npt.NDArray[np.float64] | sparray | LinearOperator:
         """
         Evaluate the hessian of the objective function for a given model.
@@ -139,14 +141,14 @@ class Scaled(Objective):
         """
         return self.multiplier * self.function(model)
 
-    def gradient(self, model: npt.NDArray) -> npt.NDArray[np.float64]:
+    def gradient(self, model: Model) -> npt.NDArray[np.float64]:
         """
         Evaluate the gradient of the objective function for a given model.
         """
         return self.multiplier * self.function.gradient(model)
 
     def hessian(
-        self, model: npt.NDArray
+        self, model: Model
     ) -> npt.NDArray[np.float64] | sparray | LinearOperator:
         """
         Evaluate the hessian of the objective function for a given model.
@@ -232,14 +234,14 @@ class Combo(Objective):
         """
         return sum(f(model) for f in self.functions)
 
-    def gradient(self, model: npt.NDArray) -> npt.NDArray[np.float64]:
+    def gradient(self, model: Model) -> npt.NDArray[np.float64]:
         """
         Evaluate the gradient of the objective function for a given model.
         """
         return sum(f.gradient(model) for f in self.functions)
 
     def hessian(
-        self, model: npt.NDArray
+        self, model: Model
     ) -> npt.NDArray[np.float64] | sparray | LinearOperator:
         """
         Evaluate the hessian of the objective function for a given model.

--- a/src/inversion_ideas/constructors.py
+++ b/src/inversion_ideas/constructors.py
@@ -4,9 +4,6 @@ Functions to easily build commonly used objects in inversions.
 
 from collections.abc import Callable
 
-import numpy as np
-import numpy.typing as npt
-
 from .base import Minimizer, Objective
 from .conditions import ChiTarget, ObjectiveChanged
 from .data_misfit import DataMisfit
@@ -22,7 +19,7 @@ def create_inversion(
     model_norm: Objective,
     *,
     starting_beta: float,
-    initial_model: npt.NDArray[np.float64],
+    initial_model: Model,
     minimizer: Minimizer | Callable[[Objective, Model], Model],
     beta_cooling_factor: float = 2.0,
     beta_cooling_rate: int = 1,

--- a/src/inversion_ideas/directives.py
+++ b/src/inversion_ideas/directives.py
@@ -3,7 +3,6 @@ Directives to modify the objective function between iterations of an inversion.
 """
 
 import numpy as np
-import numpy.typing as npt
 
 from ._utils import extract_from_combo
 from .base import Combo, Directive, Objective, Scaled, Simulation
@@ -44,7 +43,7 @@ class MultiplierCooler(Directive):
         self.cooling_factor = cooling_factor
         self.cooling_rate = cooling_rate
 
-    def __call__(self, model: npt.NDArray[np.float64], iteration: int):  # noqa: ARG002
+    def __call__(self, model: Model, iteration: int):  # noqa: ARG002
         """
         Cool the multiplier.
         """

--- a/src/inversion_ideas/inversion_log.py
+++ b/src/inversion_ideas/inversion_log.py
@@ -6,8 +6,6 @@ import numbers
 import typing
 from collections.abc import Callable, Iterable
 
-import numpy as np
-import numpy.typing as npt
 from rich.console import Console
 from rich.live import Live
 from rich.table import Table
@@ -113,7 +111,7 @@ class InversionLog:
             self._log: dict[str, list] = {col: [] for col in self.columns}
         return self._log
 
-    def update(self, iteration: int, model: npt.NDArray[np.float64]):
+    def update(self, iteration: int, model: Model):
         """
         Update the log.
         """
@@ -268,7 +266,7 @@ class InversionLogRich(InversionLog):
             fmt = ""
         return fmt
 
-    def update(self, iteration: int, model: npt.NDArray[np.float64]):
+    def update(self, iteration: int, model: Model):
         """
         Update the log.
 

--- a/src/inversion_ideas/minimize/_minimizers.py
+++ b/src/inversion_ideas/minimize/_minimizers.py
@@ -62,7 +62,7 @@ class GaussNewtonConjugateGradient(Minimizer):
     def __call__(
         self,
         objective: Objective,
-        initial_model: npt.NDArray[np.float64],
+        initial_model: Model,
         preconditioner: Preconditioner
         | Callable[[Model], Preconditioner]
         | None = None,

--- a/src/inversion_ideas/minimize/_utils.py
+++ b/src/inversion_ideas/minimize/_utils.py
@@ -6,11 +6,12 @@ import numpy as np
 import numpy.typing as npt
 
 from ..base import Objective
+from ..typing import Model
 
 
 def backtracking_line_search(
     phi: Objective,
-    model: npt.NDArray[np.float64],
+    model: Model,
     search_direction: npt.NDArray[np.float64],
     *,
     contraction_factor: float = 0.5,

--- a/src/inversion_ideas/preconditioners.py
+++ b/src/inversion_ideas/preconditioners.py
@@ -2,11 +2,10 @@
 Classes and functions to build preconditioners.
 """
 
-import numpy as np
-import numpy.typing as npt
 from scipy.sparse import diags_array, sparray
 
 from .base import Objective
+from .typing import Model
 
 
 class JacobiPreconditioner:
@@ -31,7 +30,7 @@ class JacobiPreconditioner:
     def __init__(self, objective_function: Objective):
         self.objective_function = objective_function
 
-    def __call__(self, model: npt.NDArray[np.float64]) -> sparray:
+    def __call__(self, model: Model) -> sparray:
         """
         Generate a Jacobi preconditioner as a sparse diagonal array for a given model.
 
@@ -48,9 +47,7 @@ class JacobiPreconditioner:
         return get_jacobi_preconditioner(self.objective_function, model)
 
 
-def get_jacobi_preconditioner(
-    objective_function: Objective, model: npt.NDArray[np.float64]
-):
+def get_jacobi_preconditioner(objective_function: Objective, model: Model):
     r"""
     Obtain a Jacobi preconditioner from an objective function.
 


### PR DESCRIPTION
Replace the old `npt.NDArray[np.float64]` in type hints for the `Model` type alias.
