### PR TITLE
Bump SimPEG, pymatsolver and discretize versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,9 +8,9 @@ dependencies:
   - numpy>=2.0.0
   - scipy
   - rich
-  - simpeg==0.24
-  - pymatsolver==0.3.1  # need to pin it for simpeg v0.24.0
-  - discretize==0.11
+  - simpeg==0.25
+  - pymatsolver==0.4.0
+  - discretize==0.12.0
   # Required by notebooks
   - harmonica
   - verde

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
     "scipy",
     "rich",
     "simpeg==0.24.0",
-    "pymatsolver==0.3.1",  # need to pin it for simpeg v0.24.0
-    "discretize==0.11.3",
+    "pymatsolver==0.4.0",
+    "discretize==0.12.0",
 ]
 
 [build-system]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ pytest
 ruff
 mypy
 scipy-stubs
-discretize==0.11.3
-simpeg==0.24.0
-pymatsolver==0.3.1
+discretize==0.12.0
+simpeg==0.25.0
+pymatsolver==0.4.0


### PR DESCRIPTION
Bump SimPEG to v0.25.0. Bump versions of discretize and pymatsolver to meet minimum requirements by SimPEG v0.25.0.
