### PR TITLE
Add a SparseArray type alias

### DIFF
--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -10,10 +10,9 @@ from typing import Self
 
 import numpy as np
 import numpy.typing as npt
-from scipy.sparse import sparray
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
-from ..typing import Model
+from ..typing import Model, SparseArray
 
 
 class Objective(ABC):
@@ -51,7 +50,7 @@ class Objective(ABC):
     @abstractmethod
     def hessian(
         self, model: Model
-    ) -> npt.NDArray[np.float64] | sparray | LinearOperator:
+    ) -> npt.NDArray[np.float64] | SparseArray | LinearOperator:
         """
         Evaluate the hessian of the objective function for a given model.
         """
@@ -150,7 +149,7 @@ class Scaled(Objective):
 
     def hessian(
         self, model: Model
-    ) -> npt.NDArray[np.float64] | sparray | LinearOperator:
+    ) -> npt.NDArray[np.float64] | SparseArray | LinearOperator:
         """
         Evaluate the hessian of the objective function for a given model.
         """
@@ -243,7 +242,7 @@ class Combo(Objective):
 
     def hessian(
         self, model: Model
-    ) -> npt.NDArray[np.float64] | sparray | LinearOperator:
+    ) -> npt.NDArray[np.float64] | SparseArray | LinearOperator:
         """
         Evaluate the hessian of the objective function for a given model.
         """
@@ -362,8 +361,8 @@ def _get_n_params(functions: list) -> int:
 
 
 def _sum(
-    operators: Iterator[npt.NDArray | sparray | LinearOperator],
-) -> npt.NDArray | sparray | LinearOperator:
+    operators: Iterator[npt.NDArray | SparseArray | LinearOperator],
+) -> npt.NDArray | SparseArray | LinearOperator:
     """
     Sum objects within an iterator.
 

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -4,11 +4,11 @@ Class to represent a data misfit term.
 
 import numpy as np
 import numpy.typing as npt
-from scipy.sparse import dia_array, diags_array, sparray
+from scipy.sparse import dia_array, diags_array
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 from .base import Objective
-from .typing import Model
+from .typing import Model, SparseArray
 
 
 class DataMisfit(Objective):
@@ -103,7 +103,7 @@ class DataMisfit(Objective):
 
     def hessian(
         self, model: Model
-    ) -> npt.NDArray[np.float64] | sparray | LinearOperator:
+    ) -> npt.NDArray[np.float64] | SparseArray | LinearOperator:
         """
         Hessian matrix.
         """

--- a/src/inversion_ideas/minimize/_functions.py
+++ b/src/inversion_ideas/minimize/_functions.py
@@ -33,12 +33,12 @@ def conjugate_gradient(
         Objective function to be minimized.
     initial_model : (n_params) array
         Initial model used to start the minimization.
-    preconditioner : (n_params, n_params) array, sparray or LinearOperator or Callable, optional
+    preconditioner : (n_params, n_params) array, sparse array or LinearOperator or Callable, optional
         Matrix used as preconditioner in the conjugant gradient algorithm.
         If None, no preconditioner will be used.
         A callable can be passed to build the preconditioner dynamically: such
         callable should take a single ``initial_model`` argument and return an
-        array, `sparray` or a `LinearOperator`.
+        array, sparse array or a `LinearOperator`.
     kwargs : dict
         Extra arguments that will be passed to the :func:`scipy.sparse.linalg.cg`
         function.

--- a/src/inversion_ideas/preconditioners.py
+++ b/src/inversion_ideas/preconditioners.py
@@ -2,10 +2,10 @@
 Classes and functions to build preconditioners.
 """
 
-from scipy.sparse import diags_array, sparray
+from scipy.sparse import diags_array
 
 from .base import Objective
-from .typing import Model
+from .typing import Model, SparseArray
 
 
 class JacobiPreconditioner:
@@ -30,7 +30,7 @@ class JacobiPreconditioner:
     def __init__(self, objective_function: Objective):
         self.objective_function = objective_function
 
-    def __call__(self, model: Model) -> sparray:
+    def __call__(self, model: Model) -> SparseArray:
         """
         Generate a Jacobi preconditioner as a sparse diagonal array for a given model.
 

--- a/src/inversion_ideas/recipes.py
+++ b/src/inversion_ideas/recipes.py
@@ -66,7 +66,7 @@ def create_l2_inversion(
         no limit on the total amount of iterations.
     cache_models : bool, optional
         Whether to cache models after each iteration in the inversion.
-    preconditioner : {"jacobi"} or 2d array or sparray or LinearOperator or callable or None, optional
+    preconditioner : {"jacobi"} or 2d array or sparse array or LinearOperator or callable or None, optional
         Preconditioner that will be passed to the ``minimizer`` on every call during the
         inversion. The preconditioner can be a predefined 2d array, a sparse array or
         a LinearOperator. Alternatively, it can be a callable that takes the ``model``
@@ -182,7 +182,7 @@ def create_sparse_inversion(
         no limit on the total amount of iterations.
     cache_models : bool, optional
         Whether to cache models after each iteration in the inversion.
-    preconditioner : {"jacobi"} or 2d array or sparray or LinearOperator or callable or None, optional
+    preconditioner : {"jacobi"} or 2d array or sparse array or LinearOperator or callable or None, optional
         Preconditioner that will be passed to the ``minimizer`` on every call during the
         inversion. The preconditioner can be a predefined 2d array, a sparse array or
         a LinearOperator. Alternatively, it can be a callable that takes the ``model``

--- a/src/inversion_ideas/typing.py
+++ b/src/inversion_ideas/typing.py
@@ -6,15 +6,43 @@ from typing import Protocol, TypeAlias
 
 import numpy as np
 import numpy.typing as npt
-from scipy.sparse import sparray
+from scipy.sparse import (
+    bsr_array,
+    bsr_matrix,
+    coo_array,
+    coo_matrix,
+    csc_array,
+    csc_matrix,
+    csr_array,
+    csr_matrix,
+    dia_array,
+    dia_matrix,
+)
 from scipy.sparse.linalg import LinearOperator
+
+SparseArray: TypeAlias = (
+    bsr_array
+    | bsr_matrix
+    | coo_array
+    | coo_matrix
+    | csc_array
+    | csc_matrix
+    | csr_array
+    | csr_matrix
+    | dia_array
+    | dia_matrix
+)
+"""
+Type alias to represent sparse arrays.
+"""
 
 Model: TypeAlias = npt.NDArray[np.float64]
 """
 Type alias to represent models in the inversion framework as 1D arrays.
 """
 
-Preconditioner: TypeAlias = npt.NDArray[np.float64] | sparray | LinearOperator
+
+Preconditioner: TypeAlias = npt.NDArray[np.float64] | SparseArray | LinearOperator
 """
 Type for static preconditioners.
 

--- a/src/inversion_ideas/utils.py
+++ b/src/inversion_ideas/utils.py
@@ -8,7 +8,8 @@ import logging
 
 import numpy as np
 import numpy.typing as npt
-from scipy.sparse import sparray
+
+from .typing import SparseArray
 
 __all__ = [
     "cache_on_model",
@@ -121,7 +122,7 @@ def cache_on_model(func):
 def get_sensitivity_weights(
     jacobian: npt.NDArray[np.float64],
     *,
-    data_weights: npt.NDArray[np.float64] | sparray | None = None,
+    data_weights: npt.NDArray[np.float64] | SparseArray | None = None,
     volumes: npt.NDArray[np.float64] | None = None,
     vmin: float | None = 1e-12,
 ):

--- a/tests/test_objective_functions.py
+++ b/tests/test_objective_functions.py
@@ -1,6 +1,7 @@
 """
 Test operations for objective functions.
 """
+
 import pytest
 import numpy as np
 from scipy.sparse import diags_array, sparray


### PR DESCRIPTION
Use it instead of `sparray`, since `sparray` doesn't account for things like the `shape` or the `T` properties.
