### PR TITLE
Add `__eq__` method to objective functions

### DIFF
--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -223,6 +223,14 @@ class Scaled(Objective):
             phi_str = f"[ {phi_str} ]"
         return rf"${multiplier} \, {phi_str}$"
 
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Scaled):
+            return False
+        return self.multiplier == other.multiplier and self.function == other.function
+
+    def __hash__(self):
+        return hash((self.multiplier, self.function))
+
     def __imul__(self, value: Real) -> Self:
         self.multiplier *= value
         return self
@@ -236,6 +244,9 @@ class Combo(Objective):
     """
     Sum of objective functions.
     """
+
+    # Combo behaves like a list and therefore it's not hashable
+    __hash__ = None
 
     def __init__(self, functions: list[Objective]):
         if not isinstance(functions, Sequence):
@@ -359,6 +370,16 @@ class Combo(Objective):
             functions.append(function_str)
         phi_str = " + ".join(functions)
         return f"${phi_str}$"
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Combo):
+            return False
+        if len(self) != len(other):
+            return False
+        for self_term, other_term in zip(self, other, strict=True):
+            if self_term != other_term:
+                return False
+        return True
 
     def __iadd__(self, other) -> Self:
         if other.n_params != self.n_params:

--- a/tests/base/test_objective_functions.py
+++ b/tests/base/test_objective_functions.py
@@ -803,3 +803,98 @@ class TestFloatToString:
     )
     def test_float_to_str(self, number, string):
         assert _float_to_str(number) == string
+
+
+class TestEquality:
+    """Test equality conditions between objective functions."""
+
+    def test_equal_objective(self):
+        phi_a = Dummy(3)
+        phi_b = phi_a
+        assert phi_a == phi_b
+        phi_c = Dummy(3)
+        assert phi_a != phi_c
+
+    def test_equal_scaled(self):
+        phi_a = Dummy(3)
+        scaled_a = 3.0 * phi_a
+        scaled_b = 3.0 * phi_a
+        assert scaled_a == scaled_b
+
+        scaled_a = 3.0 * phi_a
+        scaled_b = -3.0 * phi_a
+        assert scaled_a != scaled_b
+
+        phi_b = Dummy(3)
+        scaled_a = 3.0 * phi_a
+        scaled_b = 3.0 * phi_b
+        assert scaled_a != scaled_b
+
+        scaled_a = 3.0 * phi_a
+        scaled_b = 2.0 * phi_b
+        assert scaled_a != scaled_b
+
+        scaled = 5.0 * phi_a
+        assert scaled != phi_a
+        scaled = 1.0 * phi_a
+        assert scaled != phi_a
+
+    def test_equal_combo(self):
+        phi_a, phi_b, phi_c = [Dummy(3) for _ in range(3)]
+
+        # Two different combos with same functions are equal
+        combo_1 = phi_a + phi_b
+        combo_2 = phi_a + phi_b
+        assert combo_1 == combo_2
+        combo_1 = phi_a + phi_b + phi_c
+        combo_2 = phi_a + phi_b + phi_c
+        assert combo_1 == combo_2
+
+        # Combos with same functions but different structure are not equal
+        combo_1 = (phi_a + phi_b + phi_c).flatten()
+        combo_2 = (phi_a + phi_b) + phi_c
+        assert combo_1 != combo_2
+
+        # Combos with scaled with same multipliers are equal
+        combo_1 = 3.0 * phi_a + 2.1 * phi_b
+        combo_2 = 3.0 * phi_a + 2.1 * phi_b
+        assert combo_1 == combo_2
+
+        # Combos with scaled with different multipliers are not equal
+        combo_1 = 3.0 * phi_a + 2.1 * phi_b
+        combo_2 = 6.0 * phi_a + 4.1 * phi_b
+        assert combo_1 != combo_2
+
+        # Combos are never equal to non-combos
+        combo = phi_a + phi_b
+        assert combo != phi_a
+        assert combo != 3.0 * phi_a
+
+        # Combos with different lengths are not equal
+        combo_1 = phi_a + phi_b + phi_c
+        combo_2 = phi_a + phi_b
+        assert combo_1 != combo_2
+
+        # Combos with functions in different order are not equal
+        combo_1 = phi_a + phi_b
+        combo_2 = phi_b + phi_a
+        assert combo_1 != combo_2
+
+    def test_equal_nested_combo(self):
+        phi_a, phi_b, phi_c, phi_d = [Dummy(3) for _ in range(4)]
+
+        # Nested combos should be the same if they have the same structure
+        combo_1 = (phi_a + phi_b) + (phi_c + phi_d)
+        combo_2 = (phi_a + phi_b) + (phi_c + phi_d)
+        assert combo_1 == combo_2
+
+        # Nested combos with different structures should be different
+        combo_1 = (phi_b + phi_a) + (phi_c + phi_d)
+        combo_2 = (phi_a + phi_b) + (phi_c + phi_d)
+        assert combo_1 != combo_2
+        combo_1 = (phi_a + phi_b) + (phi_d + phi_c)
+        combo_2 = (phi_a + phi_b) + (phi_c + phi_d)
+        assert combo_1 != combo_2
+        combo_1 = (phi_a + phi_b + phi_c) + phi_d
+        combo_2 = (phi_a + phi_b) + (phi_c + phi_d)
+        assert combo_1 != combo_2

--- a/tests/base/test_objective_functions.py
+++ b/tests/base/test_objective_functions.py
@@ -896,3 +896,37 @@ class TestEquality:
         combo_1 = (phi_a + phi_b + phi_c) + phi_d
         combo_2 = (phi_a + phi_b) + (phi_c + phi_d)
         assert combo_1 != combo_2
+
+
+class TestHash:
+    """
+    Test hash operations for objective functions.
+
+    The ``Objective`` and ``Scaled`` objects are hashable, but the ``Combo`` is not,
+    since it behaves like a list.
+    """
+
+    def test_objective(self):
+        phi_a, phi_b = Dummy(3), Dummy(3)
+        assert hash(phi_a) == hash(phi_a)
+        assert hash(phi_a) != hash(phi_b)
+
+    def test_scaled(self):
+        scaled_a, scaled_b = 3.0 * Dummy(3), 3.0 * Dummy(3)
+        assert hash(scaled_a) == hash(scaled_a)
+        assert hash(scaled_a) != hash(scaled_b)
+
+        phi = Dummy(3)
+        scaled_a = 3.0 * phi
+        scaled_b = 3.0 * phi
+        assert hash(scaled_a) == hash(scaled_b)
+
+    def test_combo(self):
+        """
+        Test that Combo is not hashable.
+        """
+        phi_a, phi_b = Dummy(3), Dummy(3)
+        combo = phi_a + phi_b
+        assert combo.__hash__ is None
+        with pytest.raises(TypeError):
+            hash(combo)


### PR DESCRIPTION
Allow comparing two objective functions with the `==` binary operator and check if they are equal or not. Add tests for equality. Make the `Combo` class non-hashable, similarly to a list. Make `Objective` and `Scaled` hashable objects, while make `Combo` a non-hashable one, similar to a list.
