### PR TITLE
Replace `hessian_diag` for `hessian_approx`

### DIFF
--- a/src/inversion_ideas/__init__.py
+++ b/src/inversion_ideas/__init__.py
@@ -2,7 +2,7 @@
 Ideas for inversion framework.
 """
 
-from . import base, typing, utils
+from . import base, operators, typing, utils
 from ._version import __version__
 from .conditions import ChiTarget, CustomCondition, ModelChanged, ObjectiveChanged
 from .data_misfit import DataMisfit
@@ -50,6 +50,7 @@ __all__ = [
     "create_sparse_inversion",
     "create_tikhonov_regularization",
     "get_jacobi_preconditioner",
+    "operators",
     "typing",
     "utils",
     "wrap_simulation",

--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -59,7 +59,7 @@ class Objective(ABC):
 
     def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
         """
-        Approximate version of the Hessian.
+        Approximated version of the Hessian.
 
         Parameters
         ----------

--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -57,11 +57,28 @@ class Objective(ABC):
         Evaluate the hessian of the objective function for a given model.
         """
 
-    @abstractmethod
-    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
+    def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
         """
-        Diagonal of the Hessian.
+        Approximate version of the Hessian.
+
+        Parameters
+        ----------
+        model : (n_params) array
+            Array with model values.
+
+        Returns
+        -------
+        (n_params, n_params) array or sparse array
+            2D array that approximates the Hessian of the objective function.
         """
+        hessian = self.hessian(model)
+        if isinstance(hessian, LinearOperator):
+            msg = (
+                f"Cannot build a 'hessian_approx' for objective function '{self}', "
+                "since its Hessian is a LinearOperator."
+            )
+            raise TypeError(msg)
+        return hessian
 
     @property
     def name(self) -> str | None:
@@ -203,11 +220,8 @@ class Scaled(Objective):
         """
         return self.multiplier * self.function.hessian(model)
 
-    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
-        """
-        Diagonal of the Hessian.
-        """
-        return self.multiplier * self.function.hessian_diagonal(model)
+    def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
+        return self.multiplier * self.function.hessian_approx(model)
 
     def info(self):
         type_ = type(self)
@@ -333,13 +347,10 @@ class Combo(Objective):
         """
         return _sum(f.hessian(model) for f in self.functions)
 
-    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
-        """
-        Diagonal of the Hessian.
-        """
+    def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
         return sum(
-            (f.hessian_diagonal(model) for f in self.functions),
-            start=np.zeros(self.n_params),
+            (f.hessian_approx(model) for f in self.functions),
+            start=np.zeros((self.n_params, self.n_params)),
         )
 
     def flatten(self) -> "Combo":

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -115,7 +115,7 @@ class DataMisfit(Objective):
 
     def hessian_approx(self, model: Model) -> dia_array:
         """
-        Approximate version of the Hessian.
+        Approximated version of the Hessian.
 
         Approximates the Hessian by a diagonal matrix whose diagonal is the diagonal
         of the Hessian of the objective function.

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -108,17 +108,28 @@ class DataMisfit(Objective):
         Hessian matrix.
         """
         jac = self.simulation.jacobian(model)
+
+        if self.build_hessian and isinstance(jac, LinearOperator):
+            msg = (
+                f"Cannot build Hessian for DataMisfit '{self}' since the Jacobian "
+                f"of {self.simulation} is a LinearOperator. "
+                f"Set `build_hessian` to False in '{self}', or adjust your "
+                "simulation to return a dense or sparse Jacobian matrix."
+            )
+            raise TypeError(msg)
+
         if not self.build_hessian:
             jac = aslinearoperator(jac)
         weights_matrix = aslinearoperator(self.weights_matrix)
         return 2 * jac.T @ weights_matrix.T @ weights_matrix @ jac
 
-    def hessian_approx(self, model: Model) -> dia_array:
+    def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
         """
         Approximated version of the Hessian.
 
-        Approximates the Hessian by a diagonal matrix whose diagonal is the diagonal
-        of the Hessian of the objective function.
+        If ``build_hessian`` is True, then the full Hessian will be returned.
+        Otherwise, the Hessian will be approximated by a diagonal sparse matrix, whose
+        main diagonal matches Hessian's diagonal.
 
         Parameters
         ----------
@@ -127,19 +138,28 @@ class DataMisfit(Objective):
 
         Returns
         -------
-        (n_params, n_params) sparse array
+        (n_params, n_params) dense or sparse array
             2D diagonal sparse array that approximates the Hessian of the objective
             function.
         """
+        if self.build_hessian:
+            # Ignore type error: if build_hessian is True, then hessian(model) will
+            # always return a dense or sparse array.
+            return self.hessian(model)  # type: ignore[return-value]
+
         jac = self.simulation.jacobian(model)
         if isinstance(jac, LinearOperator):
-            msg = (
-                "`DataMisfit.hessian_approx` is not implemented for simulations "
-                "that return the jacobian as a LinearOperator."
+            # Repeat hessian implementation here to avoid recomputing the jacobian
+            weights_matrix = aslinearoperator(self.weights_matrix)
+            hessian = 2 * jac.T @ weights_matrix.T @ weights_matrix @ jac
+            # Estimate diagonal
+            basis = np.eye(self.n_params)
+            diagonal = np.fromiter(
+                ((e.T @ hessian @ e) for e in basis), dtype=np.float64
             )
-            raise NotImplementedError(msg)
-        jtj_diag = np.einsum("i,ij,ij->j", self.weights, jac, jac)
-        diagonal = 2 * jtj_diag
+        else:
+            jtj_diag = np.einsum("i,ij,ij->j", self.weights, jac, jac)
+            diagonal = 2 * jtj_diag
         return diags_array(diagonal)
 
     @property

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -7,6 +7,8 @@ import numpy.typing as npt
 from scipy.sparse import dia_array, diags_array
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
+from inversion_ideas.utils import get_logger
+
 from .base import Objective
 from .operators import get_diagonal
 from .typing import Model, SparseArray
@@ -153,7 +155,15 @@ class DataMisfit(Objective):
             # Repeat hessian implementation here to avoid recomputing the jacobian
             weights_matrix = aslinearoperator(self.weights_matrix)
             hessian = 2 * jac.T @ weights_matrix.T @ weights_matrix @ jac
-            # Estimate diagonal
+
+            # -- Debug --
+            get_logger().debug(
+                f"Computing the diagonal of the Hessian matrix of '{self}' "
+                "by applying projections to unit vectors of standard basis."
+            )
+            # ---
+
+            # Compute the diagonal
             diagonal = get_diagonal(hessian)
         else:
             diagonal = 2 * np.einsum("i,ij,ij->j", self.weights, jac, jac)

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -8,6 +8,7 @@ from scipy.sparse import dia_array, diags_array
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 from .base import Objective
+from .operators import get_diagonal
 from .typing import Model, SparseArray
 
 
@@ -153,10 +154,7 @@ class DataMisfit(Objective):
             weights_matrix = aslinearoperator(self.weights_matrix)
             hessian = 2 * jac.T @ weights_matrix.T @ weights_matrix @ jac
             # Estimate diagonal
-            basis = np.eye(self.n_params)
-            diagonal = np.fromiter(
-                ((e.T @ hessian @ e) for e in basis), dtype=np.float64
-            )
+            diagonal = get_diagonal(hessian)
         else:
             jtj_diag = np.einsum("i,ij,ij->j", self.weights, jac, jac)
             diagonal = 2 * jtj_diag

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -140,8 +140,8 @@ class DataMisfit(Objective):
         Returns
         -------
         (n_params, n_params) dense or sparse array
-            2D diagonal sparse array that approximates the Hessian of the objective
-            function.
+            2D diagonal dense or sparse array that approximates the Hessian of the
+            objective function.
         """
         if self.build_hessian:
             # Ignore type error: if build_hessian is True, then hessian(model) will

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -113,19 +113,34 @@ class DataMisfit(Objective):
         weights_matrix = aslinearoperator(self.weights_matrix)
         return 2 * jac.T @ weights_matrix.T @ weights_matrix @ jac
 
-    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
+    def hessian_approx(self, model: Model) -> dia_array:
         """
-        Diagonal of the Hessian.
+        Approximate version of the Hessian.
+
+        Approximates the Hessian by a diagonal matrix whose diagonal is the diagonal
+        of the Hessian of the objective function.
+
+        Parameters
+        ----------
+        model : (n_params) array
+            Array with model values.
+
+        Returns
+        -------
+        (n_params, n_params) sparse array
+            2D diagonal sparse array that approximates the Hessian of the objective
+            function.
         """
         jac = self.simulation.jacobian(model)
         if isinstance(jac, LinearOperator):
             msg = (
-                "`DataMisfit.hessian_diagonal()` is not implemented for simulations "
+                "`DataMisfit.hessian_approx` is not implemented for simulations "
                 "that return the jacobian as a LinearOperator."
             )
             raise NotImplementedError(msg)
         jtj_diag = np.einsum("i,ij,ij->j", self.weights_matrix.diagonal(), jac, jac)
-        return 2 * jtj_diag
+        diagonal = 2 * jtj_diag
+        return diags_array(diagonal)
 
     @property
     def n_params(self):

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -156,8 +156,7 @@ class DataMisfit(Objective):
             # Estimate diagonal
             diagonal = get_diagonal(hessian)
         else:
-            jtj_diag = np.einsum("i,ij,ij->j", self.weights, jac, jac)
-            diagonal = 2 * jtj_diag
+            diagonal = 2 * np.einsum("i,ij,ij->j", self.weights, jac, jac)
         return diags_array(diagonal)
 
     @property

--- a/src/inversion_ideas/operators.py
+++ b/src/inversion_ideas/operators.py
@@ -1,0 +1,103 @@
+"""
+Custom LinearOperator classes and utilities.
+"""
+
+import numpy as np
+import numpy.typing as npt
+from scipy.sparse.linalg import LinearOperator
+
+from inversion_ideas.typing import HasDiagonal, SparseArray
+
+
+def get_diagonal(operator: npt.NDArray | SparseArray | LinearOperator):
+    r"""
+    Extract diagonal of a linear operator.
+
+    Extracts the main diagonal of a square linear operator. If the operator is a dense
+    or sparse array with a ``diagonal`` method, the method will be used. For
+    :class:`~scipy.sparse.linalg.LinearOperator`s or any other operator that doesn't
+    implement the ``diagonal`` method, the diagonal will be computed by ``N``
+    projections using the unit vectors of the standard basis of :math:`\mathcal{R}^N`.
+
+    .. important::
+
+        Extracting the diagonal of a :class:`~scipy.sparse.linalg.LinearOperator`
+        requires computing multiple dot products. This can be quite expensive for large
+        operators.
+
+    Parameters
+    ----------
+    operator : (n, n) array, sparse array or LinearOperator
+        Square linear operator from which the diagonal will be extracted.
+
+    Returns
+    -------
+    diagonal : (n,) array
+        1D array containing the diagonal of the linear operator.
+
+    Notes
+    -----
+    Consider a :math:`N \times N` linear operator :math:`A`, and let
+    :math:`\{ e_i \}_1^N` be the standard basis for :math:`\mathcal{R}^N`.
+    The :math:`i`-th diagonal element of :math:`A` (:math:`a_{ii}`) can be obtained as:
+
+    .. math::
+
+        a_{ii} = e_i^T A e_i
+
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.sparse.linalg import aslinearoperator
+
+    Build a linear operator from a matrix, and extract its diagonal:
+
+    >>> a_matrix = np.array(
+    ...     [
+    ...      [1., 2., 3.],
+    ...      [4., 5., 6.],
+    ...      [7., 8., 9.],
+    ...     ]
+    ... )
+    >>> linop = aslinearoperator(a_matrix)
+    >>> get_diagonal(linop)
+    array([1., 5., 9.])
+    """
+    shape = operator.shape
+    if shape[0] != shape[1]:
+        msg = (
+            f"Invalid operator '{operator}' with shape '{shape}'. "
+            "It must be a square linear operator."
+        )
+        raise ValueError(msg)
+
+    if isinstance(operator, HasDiagonal):
+        return operator.diagonal()
+
+    n, _ = shape
+    basis = _get_standard_basis(n)
+    diagonal = np.fromiter((e.T @ operator @ e for e in basis), dtype=operator.dtype)
+    return diagonal
+
+
+def _get_standard_basis(ndim: int, dtype=np.float64):
+    r"""
+    Generate the unit vectors of the standard basis of :math:`\mathcal{R}^N`.
+
+    Parameters
+    ----------
+    ndim: int
+        Number of dimensions of the vector space.
+    dtype : dtype, optional
+        Data type of the yielded arrays.
+
+    Yields
+    ------
+    (n,) array
+        Array representing the i-th unit vector.
+    """
+    for i in range(ndim):
+        vector = np.zeros(ndim, dtype=dtype)
+        vector[i] = 1
+        yield vector

--- a/src/inversion_ideas/preconditioners.py
+++ b/src/inversion_ideas/preconditioners.py
@@ -76,7 +76,7 @@ def get_jacobi_preconditioner(objective_function: Objective, model: Model):
     where :math:`\bar{\bar{\nabla}} \phi(\mathbf{m})` is the Hessian of
     :math:`\phi(\mathbf{m})`.
     """
-    hessian_diag = objective_function.hessian_diagonal(model)
+    hessian_diag = objective_function.hessian_approx(model).diagonal()
 
     # Compute inverse only for non-zero elements
     zeros = hessian_diag == 0.0

--- a/src/inversion_ideas/regularization/_general.py
+++ b/src/inversion_ideas/regularization/_general.py
@@ -101,17 +101,6 @@ class TikhonovZero(Objective):
         weights_matrix = self.weights_matrix
         return 2 * weights_matrix.T @ weights_matrix
 
-    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
-        """
-        Diagonal of the Hessian.
-
-        Parameters
-        ----------
-        model : (n_params) array
-            Array with model values.
-        """
-        return self.hessian(model).diagonal()
-
     @property
     def n_params(self):
         """

--- a/src/inversion_ideas/regularization/_mesh_based.py
+++ b/src/inversion_ideas/regularization/_mesh_based.py
@@ -221,17 +221,6 @@ class Smallness(_MeshBasedRegularization):
             @ cell_volumes_sqrt
         )
 
-    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
-        """
-        Diagonal of the Hessian.
-
-        Parameters
-        ----------
-        model : (n_params) array
-            Array with model values.
-        """
-        return self.hessian(model).diagonal()
-
     @property
     def weights_matrix(self) -> dia_array:
         """
@@ -429,17 +418,6 @@ class Flatness(_MeshBasedRegularization):
             @ cell_volumes_sqrt
             @ cell_gradient
         )
-
-    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
-        """
-        Diagonal of the Hessian.
-
-        Parameters
-        ----------
-        model : (n_params) array
-            Array with model values.
-        """
-        return self.hessian(model).diagonal()
 
     @property
     def weights_matrix(self) -> dia_array:
@@ -663,12 +641,6 @@ class SparseSmallness(_MeshBasedRegularization):
             @ cell_volumes_sqrt
             @ r_matrix
         )
-
-    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
-        """
-        Diagonal of the Hessian.
-        """
-        return self.hessian(model).diagonal()
 
     @property
     def weights_matrix(self) -> dia_array:

--- a/src/inversion_ideas/typing.py
+++ b/src/inversion_ideas/typing.py
@@ -3,7 +3,7 @@ Custom types used for type hints.
 """
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Protocol, TypeAlias, runtime_checkable
 
 import numpy as np
 import numpy.typing as npt
@@ -56,4 +56,14 @@ class Log(Protocol):
         raise NotImplementedError
 
     def get_minimizer_callback(self) -> Callable[["MinimizerResult"], None]:
+        raise NotImplementedError
+
+
+@runtime_checkable
+class HasDiagonal(Protocol):
+    """
+    Protocol to define abstract array-like objects that has a ``diagonal`` method.
+    """
+
+    def diagonal(self) -> npt.NDArray[np.float64]:
         raise NotImplementedError

--- a/tests/base/test_objective_functions.py
+++ b/tests/base/test_objective_functions.py
@@ -7,10 +7,12 @@ import re
 
 import numpy as np
 import pytest
-from scipy.sparse import dia_array, sparray
+from scipy.sparse import dia_array
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 from inversion_ideas.base import Combo, Objective, Scaled
+
+from ..utils import assert_equal_linear_operators
 
 
 class Dummy(Objective):
@@ -81,46 +83,6 @@ class Dummy(Objective):
                 msg = f"Invalid hessian_type '{self.hessian_type}'."
                 raise ValueError(msg)
         return hessian
-
-
-def assert_equal_linear_operators(a, b, to_dense=False, seed=None, **kwargs):
-    """
-    Check if two linear operators are the same.
-
-    If ``a`` and ``b`` are ``LinearOperator``s, they will be compared by computing the
-    dot product with random arrays. Only the ``matvec`` and ``rmatvec`` will be tested.
-
-    Parameters
-    ----------
-    a, b : arrays, sparse arrays, or linear operators
-        Arrays or linear operators that will be tested.
-    to_dense : bool, optional
-        If True, sparse arrays will be converted to dense arrays for testing.
-        Use False for big matrices that can be too large to fit in memory.
-    seed : int or None, optional
-        Random seed used to define a random vector to test ``LinearOperator``s.
-        This argument will be ignored if ``a`` and ``b`` are not ``LinearOperator``s.
-    **kwargs : dict
-        Extra keyword arguments that will be passed to
-        :func:`numpy.testing.assert_equal`.
-    """
-    if to_dense:
-        if isinstance(a, sparray):
-            a = a.toarray()
-        if isinstance(b, sparray):
-            b = b.toarray()
-    if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
-        np.testing.assert_equal(a, b, **kwargs)
-    else:
-        assert a.dtype == b.dtype
-        assert a.shape == b.shape
-        # matvec
-        rng = np.random.default_rng(seed=seed)
-        vector = rng.uniform(size=a.shape[1])
-        np.testing.assert_equal(a @ vector, b @ vector, **kwargs)
-        # rmatvec
-        vector = rng.uniform(size=a.shape[0])
-        np.testing.assert_equal(a.T @ vector, b.T @ vector, **kwargs)
 
 
 class TestObjectiveOperations:

--- a/tests/base/test_objective_functions.py
+++ b/tests/base/test_objective_functions.py
@@ -82,9 +82,6 @@ class Dummy(Objective):
                 raise ValueError(msg)
         return hessian
 
-    def hessian_diagonal(self, model):  # noqa: ARG002
-        return (self.a_matrix.T @ self.a_matrix).diagonal()
-
 
 def assert_equal_linear_operators(a, b, to_dense=False, seed=None, **kwargs):
     """
@@ -423,6 +420,37 @@ class TestObjectiveOperations:
         assert combo != sum(collection).flatten()
 
 
+class TestObjectiveHessianApprox:
+    """
+    Test the default implementation of ``Objective.hessian_approx``.
+    """
+
+    n_params = 5
+
+    @pytest.fixture
+    def model(self):
+        rng = np.random.default_rng(seed=42)
+        model = rng.uniform(size=self.n_params)
+        return model
+
+    @pytest.mark.parametrize("hessian_type", ["dense", "sparse"])
+    def test_hessian_approx(self, model, hessian_type):
+        """
+        Test if the default implementation returns the Hessian.
+        """
+        phi = Dummy(3, seed=42, hessian_type=hessian_type)
+        assert_equal_linear_operators(phi.hessian(model), phi.hessian_approx(model))
+
+    def test_hessian_approx_linop_error(self, model):
+        """
+        Test error on hessian_approx if hessian is a LinearOperator.
+        """
+        phi = Dummy(3, seed=42, hessian_type="linop")
+        msg = re.escape("Cannot build a 'hessian_approx' for objective function")
+        with pytest.raises(TypeError, match=msg):
+            phi.hessian_approx(model)
+
+
 class TestComboExtraMethods:
     """
     Test additional methods of the Combo class.
@@ -621,15 +649,28 @@ class TestComboMethods:
             )
         assert_equal_linear_operators(combo.hessian(model), hessian_a + hessian_b)
 
-    def test_hessian_diagonal(self, model):
+    @pytest.mark.parametrize(
+        "hessian_types",
+        [
+            pytest.param((type_a, type_b), id=f"{type_a}-{type_b}")
+            for type_a, type_b in itertools.combinations_with_replacement(
+                ("dense", "sparse"), 2
+            )
+        ],
+    )
+    def test_hessian_approx(self, model, hessian_types):
         """
-        Test the hessian_diagonal method of Combo objective functions.
+        Test the hessian_approx method of Combo objective functions.
         """
-        phi_a, phi_b = Dummy(self.n_params, seed=42), Dummy(self.n_params, seed=43)
+        type_a, type_b = hessian_types
+        rng = np.random.default_rng(seed=42)
+        phi_a = Dummy(self.n_params, seed=rng, hessian_type=type_a)
+        phi_b = Dummy(self.n_params, seed=rng, hessian_type=type_b)
         combo = phi_a + phi_b
-        np.testing.assert_allclose(
-            combo.hessian_diagonal(model),
-            phi_a.hessian_diagonal(model) + phi_b.hessian_diagonal(model),
+        assert_equal_linear_operators(
+            combo.hessian_approx(model),
+            phi_a.hessian_approx(model) + phi_b.hessian_approx(model),
+            to_dense=True,
         )
 
 
@@ -676,14 +717,17 @@ class TestScaledMethods:
             scaled.hessian(model), self.scalar * phi.hessian(model)
         )
 
-    def test_hessian_diagonal(self, model):
+    @pytest.mark.parametrize("hessian_type", ["dense", "sparse"])
+    def test_hessian_approx(self, model, hessian_type):
         """
-        Test the hessian_diagonal method of Scaled objective functions.
+        Test the hessian_approx method of Scaled objective functions.
         """
-        phi = Dummy(self.n_params)
+        phi = Dummy(self.n_params, seed=42, hessian_type=hessian_type)
         scaled = self.scalar * phi
-        np.testing.assert_allclose(
-            scaled.hessian_diagonal(model), self.scalar * phi.hessian_diagonal(model)
+        assert_equal_linear_operators(
+            scaled.hessian_approx(model),
+            self.scalar * phi.hessian_approx(model),
+            to_dense=True,
         )
 
 

--- a/tests/test_data_misfit.py
+++ b/tests/test_data_misfit.py
@@ -2,7 +2,10 @@
 Test the ``DataMisfit`` class.
 """
 
+import re
+
 import numpy as np
+import pytest
 import scipy.sparse as sp
 
 from inversion_ideas import DataMisfit
@@ -17,31 +20,113 @@ class TestDataMisfit:
 
     n_params = 10
     n_data = 25
+    rng = np.random.default_rng(seed=42)
 
-    def test_hessian_approx(self):
+    @pytest.fixture
+    def true_model(self):
+        return self.rng.uniform(size=10)
+
+    @pytest.fixture
+    def data_and_uncertainties(self, regressor_matrix, true_model):
+        """Synthetic data and uncertainties."""
+        synthetic_data = regressor_matrix @ true_model
+        std = 1e-2 * np.max(np.abs(synthetic_data))
+        noise = self.rng.normal(scale=std, size=synthetic_data.size)
+        synthetic_data += noise
+        uncertainties = np.full_like(synthetic_data, fill_value=std)
+        return synthetic_data, uncertainties
+
+    @pytest.fixture
+    def regressor_matrix(self):
+        shape = (self.n_data, self.n_params)
+        return self.rng.uniform(size=self.n_data * self.n_params).reshape(shape)
+
+    @pytest.mark.parametrize(
+        "jacobian_as_linop", [False, True], ids=["dense-jac", "linop-jac"]
+    )
+    def test_hessian_approx(
+        self, data_and_uncertainties, regressor_matrix, jacobian_as_linop
+    ):
         """
         Test the ``hessian_approx`` method.
         """
-        # Generate some random data
-        rng = np.random.default_rng(seed=42)
-        data = rng.uniform(size=self.n_data)
-        uncertainties = 1e-2 * np.ones(self.n_data)
-
-        # Build linear regressor
-        shape = (self.n_data, self.n_params)
-        X = rng.uniform(size=self.n_data * self.n_params).reshape(shape)
-        simulation = LinearRegressor(X)
+        data, uncertainties = data_and_uncertainties
 
         # Define data misfit
+        simulation = LinearRegressor(regressor_matrix, linop=jacobian_as_linop)
         data_misfit = DataMisfit(data, uncertainties, simulation)
 
         # Get approximated hessian
-        model = rng.uniform(size=self.n_params)
+        model = self.rng.uniform(size=self.n_params)
         hessian_approx = data_misfit.hessian_approx(model)
 
         # Compare with expected one
         full_hessian = DataMisfit(
-            data, uncertainties, simulation, build_hessian=True
+            data,
+            uncertainties,
+            simulation=LinearRegressor(regressor_matrix),
+            build_hessian=True,
         ).hessian(model)
         expected = sp.diags_array(full_hessian.diagonal())
         assert_allclose_linear_operators(hessian_approx, expected, to_dense=True)
+
+    def test_hessian_approx_with_dense_hessian(
+        self, data_and_uncertainties, regressor_matrix
+    ):
+        """
+        Test that ``hessian_approx`` returns the Hessian if ``build_hessian``.
+        """
+        data, uncertainties = data_and_uncertainties
+
+        # Define data misfit
+        simulation = LinearRegressor(regressor_matrix)
+        data_misfit = DataMisfit(data, uncertainties, simulation, build_hessian=True)
+
+        # Test if hessian and hessian_approx are the same
+        model = self.rng.uniform(size=self.n_params)
+        np.testing.assert_equal(
+            data_misfit.hessian(model), data_misfit.hessian_approx(model)
+        )
+
+    def test_hessian_error(self, data_and_uncertainties, regressor_matrix):
+        """
+        Test error if `build_hessian` is True and Jacobian is a linear operator.
+        """
+        data, uncertainties = data_and_uncertainties
+        simulation = LinearRegressor(regressor_matrix, linop=True)
+        data_misfit = DataMisfit(data, uncertainties, simulation, build_hessian=True)
+
+        model = self.rng.uniform(size=self.n_params)
+        msg = re.escape("Cannot build Hessian for DataMisfit")
+        with pytest.raises(TypeError, match=msg):
+            data_misfit.hessian(model)
+
+    @pytest.mark.parametrize(
+        "jacobian_as_linop", [False, True], ids=["dense-jac", "linop-jac"]
+    )
+    def test_hessian(self, data_and_uncertainties, regressor_matrix, jacobian_as_linop):
+        """
+        Compare dense Hessian vs Hessian as LinearOperator.
+        """
+        data, uncertainties = data_and_uncertainties
+
+        # Define a baseline data misfit term: dense Jacobian, build the full hessian.
+        data_misfit = DataMisfit(
+            data,
+            uncertainties,
+            simulation=LinearRegressor(regressor_matrix),
+            build_hessian=True,
+        )
+
+        # Define a test data misfit: do not build the hessian.
+        data_misfit_test = DataMisfit(
+            data,
+            uncertainties,
+            simulation=LinearRegressor(regressor_matrix, linop=jacobian_as_linop),
+            build_hessian=False,
+        )
+
+        model = self.rng.uniform(size=self.n_params)
+        assert_allclose_linear_operators(
+            data_misfit.hessian(model), data_misfit_test.hessian(model)
+        )

--- a/tests/test_data_misfit.py
+++ b/tests/test_data_misfit.py
@@ -16,6 +16,8 @@ from .utils import LinearRegressor, assert_allclose_linear_operators
 class TestDataMisfit:
     """
     Test the DataMisfit class.
+
+    Use a linear regressor as simulation to quickly test things out.
     """
 
     n_params = 10

--- a/tests/test_data_misfit.py
+++ b/tests/test_data_misfit.py
@@ -3,10 +3,11 @@ Test the ``DataMisfit`` class.
 """
 
 import numpy as np
+import scipy.sparse as sp
 
 from inversion_ideas import DataMisfit
 
-from .utils import LinearRegressor
+from .utils import LinearRegressor, assert_allclose_linear_operators
 
 
 class TestDataMisfit:
@@ -17,9 +18,9 @@ class TestDataMisfit:
     n_params = 10
     n_data = 25
 
-    def test_hessian_diagonal(self):
+    def test_hessian_approx(self):
         """
-        Test the ``hessian_diagonal`` method.
+        Test the ``hessian_approx`` method.
         """
         # Generate some random data
         rng = np.random.default_rng(seed=42)
@@ -31,12 +32,16 @@ class TestDataMisfit:
         X = rng.uniform(size=self.n_data * self.n_params).reshape(shape)
         simulation = LinearRegressor(X)
 
-        # Define data misfit. Store full hessian for the test.
-        data_misfit = DataMisfit(data, uncertainties, simulation, build_hessian=True)
+        # Define data misfit
+        data_misfit = DataMisfit(data, uncertainties, simulation)
 
-        # Compare the true diagonal of the hessian with the one returned by
-        # hessian_diagonal.
+        # Get approximated hessian
         model = rng.uniform(size=self.n_params)
-        np.testing.assert_allclose(
-            data_misfit.hessian(model).diagonal(), data_misfit.hessian_diagonal(model)
-        )
+        hessian_approx = data_misfit.hessian_approx(model)
+
+        # Compare with expected one
+        full_hessian = DataMisfit(
+            data, uncertainties, simulation, build_hessian=True
+        ).hessian(model)
+        expected = sp.diags_array(full_hessian.diagonal())
+        assert_allclose_linear_operators(hessian_approx, expected, to_dense=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,10 +4,104 @@ Test utilities.
 
 import numpy as np
 from numpy.typing import NDArray
+from scipy.sparse import sparray
 from scipy.sparse.linalg import LinearOperator
 
 from inversion_ideas.base import Simulation
+from inversion_ideas.typing import SparseArray
 from inversion_ideas.utils import cache_on_model
+
+
+def assert_equal_linear_operators(
+    a: NDArray | SparseArray | LinearOperator,
+    b: NDArray | SparseArray | LinearOperator,
+    to_dense=False,
+    seed=None,
+    **kwargs,
+):
+    """
+    Check if two linear operators are the same.
+
+    If ``a`` and ``b`` are ``LinearOperator``s, they will be compared by computing the
+    dot product with random arrays. Only the ``matvec`` and ``rmatvec`` will be tested.
+
+    Parameters
+    ----------
+    a, b : array, sparse array, or LinearOperator
+        Arrays or linear operators that will be tested.
+    to_dense : bool, optional
+        If True, sparse arrays will be converted to dense arrays for testing.
+        Use False for big matrices that can be too large to fit in memory.
+    seed : int or None, optional
+        Random seed used to define a random vector to test ``LinearOperator``s.
+        This argument will be ignored if ``a`` and ``b`` are not ``LinearOperator``s.
+    **kwargs : dict
+        Extra keyword arguments that will be passed to
+        :func:`numpy.testing.assert_equal`.
+    """
+    if to_dense:
+        if isinstance(a, sparray):
+            a = a.toarray()
+        if isinstance(b, sparray):
+            b = b.toarray()
+    if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
+        np.testing.assert_equal(a, b, **kwargs)
+    else:
+        assert a.dtype == b.dtype
+        assert a.shape == b.shape
+        # matvec
+        rng = np.random.default_rng(seed=seed)
+        vector = rng.uniform(size=a.shape[1])
+        np.testing.assert_equal(a @ vector, b @ vector, **kwargs)
+        # rmatvec
+        vector = rng.uniform(size=a.shape[0])
+        np.testing.assert_equal(a.T @ vector, b.T @ vector, **kwargs)
+
+
+def assert_allclose_linear_operators(
+    a: NDArray | SparseArray | LinearOperator,
+    b: NDArray | SparseArray | LinearOperator,
+    to_dense=False,
+    seed=None,
+    **kwargs,
+):
+    """
+    Check if two linear operators are close enough.
+
+    If ``a`` and ``b`` are ``LinearOperator``s, they will be compared by computing the
+    dot product with random arrays. Only the ``matvec`` and ``rmatvec`` will be tested.
+
+    Parameters
+    ----------
+    a, b : array, sparse array, or LinearOperator
+        Arrays or linear operators that will be tested.
+    to_dense : bool, optional
+        If True, sparse arrays will be converted to dense arrays for testing.
+        Use False for big matrices that can be too large to fit in memory.
+    seed : int or None, optional
+        Random seed used to define a random vector to test ``LinearOperator``s.
+        This argument will be ignored if ``a`` and ``b`` are not ``LinearOperator``s.
+    **kwargs : dict
+        Extra keyword arguments that will be passed to
+        :func:`numpy.testing.assert_allclose`.
+    """
+    if to_dense:
+        if isinstance(a, sparray):
+            a = a.toarray()
+        if isinstance(b, sparray):
+            b = b.toarray()
+    if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
+        np.testing.assert_allclose(a, b, **kwargs)
+    else:
+        assert a.dtype == b.dtype
+        assert a.shape == b.shape
+        # matvec
+        rng = np.random.default_rng(seed=seed)
+        vector = rng.uniform(size=a.shape[1])
+        np.testing.assert_allclose(a @ vector, b @ vector, **kwargs)
+        # rmatvec
+        vector = rng.uniform(size=a.shape[0])
+        np.testing.assert_allclose(a.T @ vector, b.T @ vector, **kwargs)
 
 
 class LinearRegressor(Simulation):


### PR DESCRIPTION
Replace the `hessian_diagonal` method for a new `hessian_approx` method that always returns a sparse or dense 2D array. Add a default implementation for the base `Objective` class that returns the hessian itself (if it's not a `LinearOperator`), so not every children has to implement it. Override the `DataMisfit.hessian_aprox` method: if `build_hessian` is True, then return the full hessian, otherwise approximate it by a diagonal matrix with the diagonal of the hessian. If the jacobian of the simulation is a `LinearOperator`, compute the diagonal by performing projections on the unit vectors of the standard basis. Update tests for the base objective function classes. Extend tests for the `DataMisfit`. Add a new `operators` submodule.
