### PR TITLE
Fix bug in `DataMisfit.hessian_diagonal`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,12 @@ ignore = [
 "__init__.py" = [
   "F401",   # Disable unused-imports errors on __init__.py
 ]
-"test/**" = [
+"tests/**" = [
   "D",   # Ignore pydocstyle warnings in tests
   "T20", # Allow print statements in tests
+]
+"tests/__init__.py" = [
+    "D104", # Allow no docstring in test __init__ files
 ]
 "notebooks/**.ipynb" = [
   "B018",   # Allow unused expression (prints on notebooks)

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -124,7 +124,7 @@ class DataMisfit(Objective):
                 "that return the jacobian as a LinearOperator."
             )
             raise NotImplementedError(msg)
-        jtj_diag = np.einsum("i,ij,ij->j", self.weights_matrix.diagonal(), jac, jac)
+        jtj_diag = np.einsum("i,ij,ij->j", self.weights, jac, jac)
         return 2 * jtj_diag
 
     @property

--- a/tests/test_data_misfit.py
+++ b/tests/test_data_misfit.py
@@ -1,0 +1,42 @@
+"""
+Test the ``DataMisfit`` class.
+"""
+
+import numpy as np
+
+from inversion_ideas import DataMisfit
+
+from .utils import LinearRegressor
+
+
+class TestDataMisfit:
+    """
+    Test the DataMisfit class.
+    """
+
+    n_params = 10
+    n_data = 25
+
+    def test_hessian_diagonal(self):
+        """
+        Test the ``hessian_diagonal`` method.
+        """
+        # Generate some random data
+        rng = np.random.default_rng(seed=42)
+        data = rng.uniform(size=self.n_data)
+        uncertainties = 1e-2 * np.ones(self.n_data)
+
+        # Build linear regressor
+        shape = (self.n_data, self.n_params)
+        X = rng.uniform(size=self.n_data * self.n_params).reshape(shape)
+        simulation = LinearRegressor(X)
+
+        # Define data misfit. Store full hessian for the test.
+        data_misfit = DataMisfit(data, uncertainties, simulation, build_hessian=True)
+
+        # Compare the true diagonal of the hessian with the one returned by
+        # hessian_diagonal.
+        model = rng.uniform(size=self.n_params)
+        np.testing.assert_allclose(
+            data_misfit.hessian(model).diagonal(), data_misfit.hessian_diagonal(model)
+        )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,48 @@
+"""
+Test utilities.
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.sparse.linalg import LinearOperator
+
+from inversion_ideas.base import Simulation
+from inversion_ideas.utils import cache_on_model
+
+
+class LinearRegressor(Simulation):
+    r"""
+    Linear regressor.
+
+    .. math::
+
+        \mathbf{y} = \mathbf{X} \cdot \mathbf{m}
+    """
+
+    def __init__(self, X, linop=False, cache=True):
+        self.X = X
+        self.linop = linop
+        self.cache = cache
+
+    @property
+    def n_params(self) -> int:
+        return self.X.shape[1]
+
+    @property
+    def n_data(self) -> int:
+        return self.X.shape[0]
+
+    @cache_on_model
+    def __call__(self, model) -> NDArray[np.float64]:
+        return self.X @ model
+
+    def jacobian(self, model) -> NDArray[np.float64] | LinearOperator:  # noqa: ARG002
+        if self.linop:
+            linear_op = LinearOperator(
+                shape=(self.n_data, self.n_params),
+                matvec=lambda model: self.X @ model,
+                rmatvec=lambda model: self.X.T @ model,
+                dtype=np.float64,
+            )
+            return linear_op
+        return self.X


### PR DESCRIPTION
Use the full `weights` array in the `einsum` when computing the diagonal of the Hessian without computing it fully. Add a test that catches the bug. Allow adding `__init__.py` modules without docstrings in tests. Fix typo in `pyproject.toml`. Include the `LinearRegressor` class in test utils.
