### PR TITLE
Improve global logger

### DIFF
--- a/src/inversion_ideas/_utils.py
+++ b/src/inversion_ideas/_utils.py
@@ -30,6 +30,10 @@ def array_to_str(array: npt.NDArray, *, single_line=True, threshold=10, **kwargs
         repr.
     kwargs : dict
         Extra keyword arguments passed to :func:`numpy.printoptions`.
+
+    Returns
+    -------
+    str
     """
     kwargs["threshold"] = threshold
     with np.printoptions(**kwargs):

--- a/src/inversion_ideas/_utils.py
+++ b/src/inversion_ideas/_utils.py
@@ -13,15 +13,30 @@ import numpy.typing as npt
 from inversion_ideas.base.objective_function import Objective, Scaled
 
 
-def array_to_str(array: npt.NDArray, threshold=10, **kwargs):
+def array_to_str(array: npt.NDArray, *, single_line=True, threshold=10, **kwargs):
     """
-    Reperesent Numpy arrays as strings.
+    Represent Numpy arrays as strings.
 
     Use this function to simplify printouts like debug lines.
+
+    Parameters
+    ----------
+    array : array
+        Numpy array to represent as string.
+    single_line : bool, optional
+        Whether to show the array in a single line or allow Numpy to break lines.
+    threshold : int, optional
+        Total number of array elements which trigger summarization rather than full
+        repr.
+    kwargs : dict
+        Extra keyword arguments passed to :func:`numpy.printoptions`.
     """
     kwargs["threshold"] = threshold
     with np.printoptions(**kwargs):
-        return f"{array}"
+        string = f"{array}"
+        if single_line:
+            string = string.replace("\n", "")
+        return string
 
 
 def prod_arrays(arrays: Iterator[npt.NDArray[np.float64]]) -> npt.NDArray[np.float64]:

--- a/src/inversion_ideas/utils.py
+++ b/src/inversion_ideas/utils.py
@@ -26,9 +26,9 @@ def _create_logger():
     logger = logging.getLogger("inversions")
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler()
-    formatter = logging.Formatter("{levelname}: {message}", style="{")
-    handler.setFormatter(formatter)
     logger.addHandler(handler)
+    formatter = logging.Formatter("[{levelname}] {asctime} | {message}", style="{")
+    handler.setFormatter(formatter)
     return logger
 
 
@@ -46,6 +46,18 @@ def get_logger():
     -------
     logger : :class:`logging.Logger`
         The logger object for SimPEG.
+
+    Examples
+    --------
+    Send an info message to the logger:
+
+    >>> get_logger().info("Testing!")
+
+    Change logging level:
+
+    >>> import logging
+    >>> logger = get_logger()
+    >>> logger.setLevel("DEBUG")
     """
     return LOGGER
 

--- a/src/inversion_ideas/utils.py
+++ b/src/inversion_ideas/utils.py
@@ -18,9 +18,6 @@ __all__ = [
     "get_sensitivity_weights",
 ]
 
-LOGGER = logging.Logger("inversions")
-LOGGER.addHandler(logging.StreamHandler())
-
 
 def _create_logger():
     """


### PR DESCRIPTION
Tweak the logger format to include the time, use pipe character to split between fields. Make `array_to_str` to return single liner by default. Remove unused lines to define the `LOGGER`.
