### PR TITLE
Fix Jacobi preconditioner and `Flatness._cell_gradient`

### DIFF
--- a/src/inversion_ideas/_utils.py
+++ b/src/inversion_ideas/_utils.py
@@ -10,7 +10,7 @@ from copy import copy
 import numpy as np
 import numpy.typing as npt
 
-from inversion_ideas.base.objective_function import Objective, Scaled
+from .base.objective_function import Objective, Scaled
 
 
 def array_to_str(array: npt.NDArray, *, single_line=True, threshold=10, **kwargs):

--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -349,10 +349,7 @@ class Combo(Objective):
         return _sum_operators(f.hessian(model) for f in self.functions)
 
     def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
-        return sum(
-            (f.hessian_approx(model) for f in self.functions),
-            start=np.zeros((self.n_params, self.n_params)),
-        )
+        return _sum_operators(f.hessian_approx(model) for f in self.functions)
 
     def flatten(self) -> "Combo":
         """

--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -11,6 +11,7 @@ from typing import Self
 
 import numpy as np
 import numpy.typing as npt
+from scipy.sparse import spmatrix
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 from ..typing import Model, SparseArray
@@ -345,7 +346,7 @@ class Combo(Objective):
         """
         Evaluate the hessian of the objective function for a given model.
         """
-        return _sum(f.hessian(model) for f in self.functions)
+        return _sum_operators(f.hessian(model) for f in self.functions)
 
     def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
         return sum(
@@ -490,14 +491,29 @@ def _get_n_params(functions: list) -> int:
     return n_params
 
 
-def _sum(
+def _sum_operators(
     operators: Iterator[npt.NDArray | SparseArray | LinearOperator],
 ) -> npt.NDArray | SparseArray | LinearOperator:
     """
-    Sum objects within an iterator.
+    Sum linear operators within an iterator.
 
-    This function supports summing together ``LinearOperator``s with Numpy arrays and
-    sparse arrays.
+    This function supports summing together
+    :class:`~scipy.sparse.linalg.LinearOperator`s with Numpy arrays and sparse arrays.
+
+    Parameters
+    ----------
+    operators : iterator
+        Iterator containing a mixed collection of Numpy arrays, sparse arrays and
+        :class:`~scipy.sparse.linalg.LinearOperator`s.
+
+    Returns
+    -------
+    array or sparse array or LinearOperator
+
+    Raises
+    ------
+    TypeError : if any operator is a sparse matrix.
+    ValueError : if ``operators`` is empty.
     """
     if not operators:
         msg = "Invalid empty 'operators' iterator when summing."
@@ -505,6 +521,14 @@ def _sum(
 
     result = copy(next(operators))
     for operator in operators:
+        if isinstance(operator, spmatrix):
+            msg = (
+                f"Invalid sparse matrix '{operator}' when summing multiple operators. "
+                "Make sure to use sparse arrays instead "
+                "(https://docs.scipy.org/doc/scipy/reference/"
+                "sparse.migration_to_sparray.html)."
+            )
+            raise TypeError(msg)
         if isinstance(operator, LinearOperator) or isinstance(result, LinearOperator):
             result = aslinearoperator(result)  # type: ignore[arg-type]
             result += aslinearoperator(operator)  # type: ignore[arg-type]

--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -489,7 +489,7 @@ def _get_n_params(functions: list) -> int:
 
 
 def _sum_operators(
-    operators: Iterator[npt.NDArray | SparseArray | LinearOperator],
+    operators: Iterable[npt.NDArray | SparseArray | LinearOperator],
 ) -> npt.NDArray | SparseArray | LinearOperator:
     """
     Sum linear operators within an iterator.
@@ -512,26 +512,40 @@ def _sum_operators(
     TypeError : if any operator is a sparse matrix.
     ValueError : if ``operators`` is empty.
     """
-    if not operators:
-        msg = "Invalid empty 'operators' iterator when summing."
-        raise ValueError(msg)
+    if not isinstance(operators, Iterator):
+        operators = iter(operators)
 
-    result = copy(next(operators))
+    # Define result as a copy of the first element in the iterator (if any).
+    try:
+        result = next(operators)
+    except StopIteration as err:
+        msg = "Invalid empty 'operators' iterator when summing."
+        raise ValueError(msg) from err
+    else:
+        _raise_if_sparse_matrix(result)
+        result = copy(result)
+
+    # Sum over operators in the iterator
     for operator in operators:
-        if isinstance(operator, spmatrix):
-            msg = (
-                f"Invalid sparse matrix '{operator}' when summing multiple operators. "
-                "Make sure to use sparse arrays instead "
-                "(https://docs.scipy.org/doc/scipy/reference/"
-                "sparse.migration_to_sparray.html)."
-            )
-            raise TypeError(msg)
+        _raise_if_sparse_matrix(operator)
         if isinstance(operator, LinearOperator) or isinstance(result, LinearOperator):
             result = aslinearoperator(result)  # type: ignore[arg-type]
             result += aslinearoperator(operator)  # type: ignore[arg-type]
         else:
             result += operator  # type: ignore[operator]
     return result
+
+
+def _raise_if_sparse_matrix(operator):
+    """Raise TypeError if operator is a sparse matrix."""
+    if isinstance(operator, spmatrix):
+        msg = (
+            f"Invalid sparse matrix '{operator}' when summing multiple operators. "
+            "Make sure to use sparse arrays instead "
+            "(https://docs.scipy.org/doc/scipy/reference/"
+            "sparse.migration_to_sparray.html)."
+        )
+        raise TypeError(msg)
 
 
 def _float_to_str(number: float, precision: int = FLOAT_TO_STR_PRECISION) -> str:

--- a/src/inversion_ideas/preconditioners.py
+++ b/src/inversion_ideas/preconditioners.py
@@ -80,6 +80,7 @@ def get_jacobi_preconditioner(objective_function: Objective, model: Model):
 
     # Compute inverse only for non-zero elements
     zeros = hessian_diag == 0.0
-    hessian_diag[~zeros] **= -1
+    preconditioner = hessian_diag.copy()
+    preconditioner[~zeros] **= -1
 
-    return diags_array(hessian_diag)
+    return diags_array(preconditioner)

--- a/src/inversion_ideas/regularization/_mesh_based.py
+++ b/src/inversion_ideas/regularization/_mesh_based.py
@@ -6,7 +6,14 @@ import discretize
 import numpy as np
 import numpy.typing as npt
 import simpeg
-from scipy.sparse import dia_array, diags_array, eye_array
+from scipy.sparse import (
+    csc_array,
+    csc_matrix,
+    dia_array,
+    diags_array,
+    eye_array,
+    isspmatrix,
+)
 
 from .._utils import prod_arrays
 from ..base import Objective
@@ -450,9 +457,19 @@ class Flatness(_MeshBasedRegularization):
     def _cell_gradient(self):
         """Return the cell gradient matrix operator."""
         if not hasattr(self, "__cell_gradient"):
-            self.__cell_gradient = getattr(
+            cell_gradient = getattr(
                 self._regularization_mesh, f"cell_gradient_{self.direction}"
             )
+            # ---
+            # Ensure that we are returning a sparse array and not a sparse matrix.
+            # This is a patch. We should fix this upstream.
+            if isspmatrix(cell_gradient):
+                if isinstance(cell_gradient, csc_matrix):
+                    cell_gradient = csc_array(cell_gradient)
+                else:
+                    raise TypeError()
+            # ---
+            self.__cell_gradient = cell_gradient
         return self.__cell_gradient
 
     @property

--- a/tests/base/test_objfun_utils.py
+++ b/tests/base/test_objfun_utils.py
@@ -6,7 +6,7 @@ import re
 
 import numpy as np
 import pytest
-from scipy.sparse import diags_array, sparray
+from scipy.sparse import diags, diags_array, sparray
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 from inversion_ideas.base.objective_function import _float_to_str, _sum_operators
@@ -51,6 +51,15 @@ class TestSumOperators:
     @pytest.fixture
     def vector(self):
         return np.random.default_rng(seed=43).uniform(size=self.shape[1])
+
+    def test_iterator_vs_iterable(self, matrices, sparse_arrays):
+        """
+        Test summing over an iterable vs an iterator.
+        """
+        operators = [*matrices, *sparse_arrays]
+        np.testing.assert_allclose(
+            _sum_operators(operators), _sum_operators(iter(operators))
+        )
 
     def test_all_arrays(self, matrices):
         # Get the sum
@@ -112,10 +121,38 @@ class TestSumOperators:
         expected = factor * a + b + c if index == 0 else a + factor * b + c
         np.testing.assert_allclose(result @ vector, expected @ vector)
 
-    def test_error_empty_operators(self):
-        msg = "Invalid empty 'operators' iterator when summing."
+    @pytest.mark.parametrize("operators_type", ["iterator", "list"])
+    def test_error_empty_operators(self, operators_type):
+        msg = re.escape("Invalid empty 'operators' iterator when summing.")
+        match operators_type:
+            case "list":
+                operators = []
+            case "iterator":
+                operators = iter(range(0))
+            case _:
+                raise ValueError()  # pragma: no cover
         with pytest.raises(ValueError, match=msg):
-            _sum_operators([])
+            _sum_operators(operators)
+
+    @pytest.mark.parametrize("position", [0, -1])
+    def test_error_sparse_matrix(self, position):
+        """Test error raised after having a sparse matrix in the collection."""
+        shape = (10, 15)
+        rng = np.random.default_rng(seed=42)
+        operators = [
+            rng.uniform(size=shape),  # a dense array
+            aslinearoperator(rng.uniform(size=shape)),  # a linear operator
+            diags_array(rng.uniform(size=shape[0]), shape=shape),  # a sparse array
+            diags_array(rng.uniform(size=shape[0]), shape=shape),  # a sparse array
+        ]
+        # Insert a sparse matrix in the list
+        sparse_matrix = diags(rng.uniform(size=shape[0]), shape=shape)
+        operators.insert(position, sparse_matrix)
+        msg = re.escape(
+            f"Invalid sparse matrix '{sparse_matrix}' when summing multiple operators."
+        )
+        with pytest.raises(TypeError, match=msg):
+            _sum_operators(operators)
 
 
 class TestFloatToString:

--- a/tests/base/test_objfun_utils.py
+++ b/tests/base/test_objfun_utils.py
@@ -9,10 +9,10 @@ import pytest
 from scipy.sparse import diags_array, sparray
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
-from inversion_ideas.base.objective_function import _float_to_str, _sum
+from inversion_ideas.base.objective_function import _float_to_str, _sum_operators
 
 
-class TestSum:
+class TestSumOperators:
     """
     Test custom sum for operators.
 
@@ -54,7 +54,7 @@ class TestSum:
 
     def test_all_arrays(self, matrices):
         # Get the sum
-        result = _sum(op for op in matrices)
+        result = _sum_operators(op for op in matrices)
 
         # We should recover a dense array
         assert isinstance(result, np.ndarray)
@@ -73,7 +73,7 @@ class TestSum:
         )
 
         # Get the sum
-        result = _sum(op for op in operators)
+        result = _sum_operators(op for op in operators)
 
         # We should recover a dense array
         assert isinstance(result, np.ndarray)
@@ -84,7 +84,7 @@ class TestSum:
         np.testing.assert_allclose(result, expected)
 
     def test_all_sparse_arrays(self, sparse_arrays):
-        result = _sum(op for op in sparse_arrays)
+        result = _sum_operators(op for op in sparse_arrays)
 
         # We should recover a sparse array
         assert isinstance(result, sparray)
@@ -102,7 +102,7 @@ class TestSum:
         operators[index] = factor * aslinearoperator(operators[index])
 
         # Get the sum
-        result = _sum(op for op in operators)
+        result = _sum_operators(op for op in operators)
 
         # We should recover a linear operator
         assert isinstance(result, LinearOperator)
@@ -115,7 +115,7 @@ class TestSum:
     def test_error_empty_operators(self):
         msg = "Invalid empty 'operators' iterator when summing."
         with pytest.raises(ValueError, match=msg):
-            _sum([])
+            _sum_operators([])
 
 
 class TestFloatToString:

--- a/tests/test_regularizations.py
+++ b/tests/test_regularizations.py
@@ -1,0 +1,26 @@
+"""
+Test regularization classes.
+"""
+
+import pytest
+from discretize.tensor_mesh import TensorMesh
+from scipy.sparse import sparray
+
+from inversion_ideas import Flatness
+
+
+class TestBugfixFlatness:
+    """
+    Test bugfix: check the `_cell_gradient` returns a sparse array and not a matrix.
+    """
+
+    @pytest.fixture
+    def mesh(self):
+        hx = [(1.0, 5)]
+        h = [hx, hx, hx]
+        return TensorMesh(h=h)
+
+    @pytest.mark.parametrize("direction", ["x", "y", "z"])
+    def test_cell_gradient_type(self, mesh, direction):
+        flatness = Flatness(mesh, direction=direction)
+        assert isinstance(flatness._cell_gradient, sparray)


### PR DESCRIPTION
Patch `Flatness.cell_gradient` to always return a sparse array (instead of sparse matrix), and test for the patch. Copy `hessian_diag` array in Jacobi preconditioner to avoid in-place modification of _borrowed_ object. Raise error in Combo if summing sparse matrices: rename private function to sum operators to `_sum_operators`, make it to raise an error if any of the operators is a sparse matrix, improve its implementation. Use the new `_sum_operators` in `Combo.hessian_approx`.