### PR TITLE
Restore `hessian_diagonal` method in objective functions

### DIFF
--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -380,7 +380,7 @@ class Combo(Objective):
 
     def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
         return sum(
-            (f.hessian_approx(model) for f in self.functions),
+            (f.hessian_diagonal(model) for f in self.functions),
             start=np.zeros(self.n_params, dtype=np.float64),
         )
 

--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -14,7 +14,7 @@ import numpy.typing as npt
 from scipy.sparse import spmatrix
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
-from ..typing import Model, SparseArray
+from ..typing import HasDiagonal, Model, SparseArray
 
 FLOAT_TO_STR_PRECISION = 3
 
@@ -57,6 +57,30 @@ class Objective(ABC):
         """
         Evaluate the hessian of the objective function for a given model.
         """
+
+    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
+        """
+        Get the main diagonal of the Hessian.
+
+        Parameters
+        ----------
+        model : (n_params) array
+            Array with model values.
+
+        Returns
+        -------
+        (n_params,) array
+            Array containing the diagonal of the Hessian.
+        """
+        hessian = self.hessian(model)
+        if not isinstance(hessian, HasDiagonal):
+            msg = (
+                f"Cannot get 'hessian_diagonal' for objective function '{self}', "
+                f"since its Hessian of type {type(hessian).__name__} doesn't implement "
+                "a `diagonal` method."
+            )
+            raise TypeError(msg)
+        return hessian.diagonal()
 
     def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
         """
@@ -224,6 +248,9 @@ class Scaled(Objective):
     def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
         return self.multiplier * self.function.hessian_approx(model)
 
+    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
+        return self.multiplier * self.function.hessian_diagonal(model)
+
     def info(self):
         type_ = type(self)
         class_name = type_.__name__
@@ -350,6 +377,12 @@ class Combo(Objective):
 
     def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
         return _sum_operators(f.hessian_approx(model) for f in self.functions)
+
+    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
+        return sum(
+            (f.hessian_approx(model) for f in self.functions),
+            start=np.zeros(self.n_params, dtype=np.float64),
+        )
 
     def flatten(self) -> "Combo":
         """
@@ -499,8 +532,8 @@ def _sum_operators(
 
     Parameters
     ----------
-    operators : iterator
-        Iterator containing a mixed collection of Numpy arrays, sparse arrays and
+    operators : iterable
+        Iterable containing a mixed collection of Numpy arrays, sparse arrays and
         :class:`~scipy.sparse.linalg.LinearOperator`s.
 
     Returns

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -36,6 +36,21 @@ class DataMisfit(Objective):
             Hessian matrices are usually very large. Use ``build_hessian=True`` only if
             you need to build it.
 
+    estimate_hessian_diagonal : bool, optional
+        If True, the ``hessian_diagonal`` and the ``hessian_approx`` methods will
+        estimate the diagonal of the Hessian, even if the Jacobian of the ``simulation``
+        is a :class:`~scipy.sparse.linalg.LinearOperator`.
+        If False, an error will be raised when calling the ``hessian_diagonal`` or the
+        ``hessian_approx`` methods in case the Jacobian of the ``simulation`` is
+        a :class:`~scipy.sparse.linalg.LinearOperator`.
+
+        .. important::
+
+            Estimating the diagonal of a :class:`~scipy.sparse.linalg.LinearOperator`
+            require a high number of dot products between the operator and multiple unit
+            vectors. This might lead to very expensive computations. Enable
+            ``estimate_hessian_diagonal`` only if you really need to.
+
     Notes
     -----
     The L2 data misfit objective function is defined as:
@@ -82,6 +97,7 @@ class DataMisfit(Objective):
         simulation,
         *,
         build_hessian=False,
+        estimate_hessian_diagonal=False,
     ):
         # TODO: Check that the data and uncertainties have the size as ndata in the
         #       simulation.
@@ -89,6 +105,7 @@ class DataMisfit(Objective):
         self.uncertainty = uncertainty
         self.simulation = simulation
         self.build_hessian = build_hessian
+        self.estimate_hessian_diagonal = estimate_hessian_diagonal
         self.set_name("d")
 
     def __call__(self, model: Model) -> float:
@@ -134,6 +151,14 @@ class DataMisfit(Objective):
         Otherwise, the Hessian will be approximated by a diagonal sparse matrix, whose
         main diagonal matches Hessian's diagonal.
 
+        .. important::
+
+            If the Jacobian of the ``simulation`` is
+            a :class:`~scipy.sparse.linalg.LinearOperator`, the diagonal of the Hessian
+            will be estimated only if ``estimate_hessian_diagonal`` is True.
+            Diagonal estimations can be expensive computational tasks for large
+            problems. Make sure you to enable diagonal estimations only if you need it.
+
         Parameters
         ----------
         model : (n_params) array
@@ -144,30 +169,73 @@ class DataMisfit(Objective):
         (n_params, n_params) dense or sparse array
             2D diagonal dense or sparse array that approximates the Hessian of the
             objective function.
+
+        See Also
+        --------
+        DataMisfit.hessian_diagonal
         """
         if self.build_hessian:
             # Ignore type error: if build_hessian is True, then hessian(model) will
             # always return a dense or sparse array.
             return self.hessian(model)  # type: ignore[return-value]
+        return diags_array(self.hessian_diagonal(model))
+
+    def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
+        """
+        Get the main diagonal of the Hessian.
+
+        .. important::
+
+            If the Jacobian of the ``simulation`` is
+            a :class:`~scipy.sparse.linalg.LinearOperator`, the diagonal of the Hessian
+            will be estimated only if ``estimate_hessian_diagonal`` is True.
+            Diagonal estimations can be expensive computational tasks for large
+            problems. Make sure you to enable diagonal estimations only if you need it.
+
+        Parameters
+        ----------
+        model : (n_params) array
+            Array with model values.
+
+        Returns
+        -------
+        (n_params,) array
+            Array containing the diagonal of the Hessian.
+        """
+        if self.build_hessian:
+            return self.hessian(model).diagonal()
 
         jac = self.simulation.jacobian(model)
         if isinstance(jac, LinearOperator):
+            if not self.estimate_hessian_diagonal:
+                msg = (
+                    f"Cannot estimate diagonal of Hessian for '{self}' since it "
+                    "has `estimate_hessian_diagonal` set to False. "
+                    "Set `estimate_hessian_diagonal` to True to allow diagonal "
+                    "estimation, or make sure your simulation returns a dense or "
+                    "sparse Jacobian matrix."
+                )
+                raise AttributeError(msg)
+
             # Repeat hessian implementation here to avoid recomputing the jacobian
             weights_matrix = aslinearoperator(self.weights_matrix)
             hessian = 2 * jac.T @ weights_matrix.T @ weights_matrix @ jac
 
             # -- Debug --
             get_logger().debug(
-                f"Computing the diagonal of the Hessian matrix of '{self}' "
-                "by applying projections to unit vectors of standard basis."
+                f"Estimating diagonal of the Heessian matrix of '{self}'."
             )
             # ---
 
-            # Compute the diagonal
+            # TODO: Extend algorithms for estimating the diagonal. Add keyword arguments
+            #       to the constructor of the DataMisfit to choose method and set
+            #       parameters.
+
+            # Compute the diagonal.
             diagonal = get_diagonal(hessian)
         else:
             diagonal = 2 * np.einsum("i,ij,ij->j", self.weights, jac, jac)
-        return diags_array(diagonal)
+        return diagonal
 
     @property
     def n_params(self):

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -223,7 +223,7 @@ class DataMisfit(Objective):
 
             # -- Debug --
             get_logger().debug(
-                f"Estimating diagonal of the Heessian matrix of '{self}'."
+                f"Estimating diagonal of the Hessian matrix of '{self}'."
             )
             # ---
 

--- a/src/inversion_ideas/preconditioners.py
+++ b/src/inversion_ideas/preconditioners.py
@@ -76,7 +76,7 @@ def get_jacobi_preconditioner(objective_function: Objective, model: Model):
     where :math:`\bar{\bar{\nabla}} \phi(\mathbf{m})` is the Hessian of
     :math:`\phi(\mathbf{m})`.
     """
-    hessian_diag = objective_function.hessian_approx(model).diagonal()
+    hessian_diag = objective_function.hessian_diagonal(model).diagonal()
 
     # Compute inverse only for non-zero elements
     zeros = hessian_diag == 0.0

--- a/tests/base/test_objective_functions.py
+++ b/tests/base/test_objective_functions.py
@@ -382,9 +382,9 @@ class TestObjectiveOperations:
         assert combo != sum(collection).flatten()
 
 
-class TestObjectiveHessianApprox:
+class TestObjectiveHessian:
     """
-    Test the default implementation of ``Objective.hessian_approx``.
+    Test the default implementation of ``hessian_approx`` and ``hessian_diagonal``.
     """
 
     n_params = 5
@@ -398,19 +398,38 @@ class TestObjectiveHessianApprox:
     @pytest.mark.parametrize("hessian_type", ["dense", "sparse"])
     def test_hessian_approx(self, model, hessian_type):
         """
-        Test if the default implementation returns the Hessian.
+        Test if the default implementation of ``hessian_approx`` returns the Hessian.
         """
         phi = Dummy(3, seed=42, hessian_type=hessian_type)
         assert_equal_linear_operators(phi.hessian(model), phi.hessian_approx(model))
 
     def test_hessian_approx_linop_error(self, model):
         """
-        Test error on hessian_approx if hessian is a LinearOperator.
+        Test error on ``hessian_approx`` if hessian is a LinearOperator.
         """
         phi = Dummy(3, seed=42, hessian_type="linop")
         msg = re.escape("Cannot build a 'hessian_approx' for objective function")
         with pytest.raises(TypeError, match=msg):
             phi.hessian_approx(model)
+
+    @pytest.mark.parametrize("hessian_type", ["dense", "sparse"])
+    def test_hessian_diagonal(self, model, hessian_type):
+        """
+        Test default implementation of ``hessian_diagonal``.
+        """
+        phi = Dummy(3, seed=42, hessian_type=hessian_type)
+        np.testing.assert_equal(
+            phi.hessian(model).diagonal(), phi.hessian_diagonal(model)
+        )
+
+    def test_hessian_diagonal_linop_error(self, model):
+        """
+        Test error on ``hessian_diagonal`` if hessian is a LinearOperator.
+        """
+        phi = Dummy(3, seed=42, hessian_type="linop")
+        msg = re.escape("Cannot get 'hessian_diagonal' for objective function")
+        with pytest.raises(TypeError, match=msg):
+            phi.hessian_diagonal(model)
 
 
 class TestComboExtraMethods:
@@ -635,6 +654,29 @@ class TestComboMethods:
             to_dense=True,
         )
 
+    @pytest.mark.parametrize(
+        "hessian_types",
+        [
+            pytest.param((type_a, type_b), id=f"{type_a}-{type_b}")
+            for type_a, type_b in itertools.combinations_with_replacement(
+                ("dense", "sparse"), 2
+            )
+        ],
+    )
+    def test_hessian_diagonal(self, model, hessian_types):
+        """
+        Test the hessian_diagonal method of Combo objective functions.
+        """
+        type_a, type_b = hessian_types
+        rng = np.random.default_rng(seed=42)
+        phi_a = Dummy(self.n_params, seed=rng, hessian_type=type_a)
+        phi_b = Dummy(self.n_params, seed=rng, hessian_type=type_b)
+        combo = phi_a + phi_b
+        np.testing.assert_equal(
+            combo.hessian_diagonal(model),
+            phi_a.hessian_diagonal(model) + phi_b.hessian_diagonal(model),
+        )
+
 
 class TestScaledMethods:
     """
@@ -682,7 +724,7 @@ class TestScaledMethods:
     @pytest.mark.parametrize("hessian_type", ["dense", "sparse"])
     def test_hessian_approx(self, model, hessian_type):
         """
-        Test the hessian_approx method of Scaled objective functions.
+        Test the ``hessian_approx`` method of Scaled objective functions.
         """
         phi = Dummy(self.n_params, seed=42, hessian_type=hessian_type)
         scaled = self.scalar * phi
@@ -690,6 +732,18 @@ class TestScaledMethods:
             scaled.hessian_approx(model),
             self.scalar * phi.hessian_approx(model),
             to_dense=True,
+        )
+
+    @pytest.mark.parametrize("hessian_type", ["dense", "sparse"])
+    def test_hessian_diagonal(self, model, hessian_type):
+        """
+        Test the ``hessian_diagonal`` method of Scaled objective functions.
+        """
+        phi = Dummy(self.n_params, seed=42, hessian_type=hessian_type)
+        scaled = self.scalar * phi
+        np.testing.assert_equal(
+            scaled.hessian_diagonal(model),
+            self.scalar * phi.hessian_diagonal(model),
         )
 
 

--- a/tests/test_data_misfit.py
+++ b/tests/test_data_misfit.py
@@ -56,8 +56,13 @@ class TestDataMisfit:
 
         # Define data misfit
         simulation = LinearRegressor(regressor_matrix, linop=jacobian_as_linop)
-        data_misfit = DataMisfit(data, uncertainties, simulation)
-
+        data_misfit = DataMisfit(
+            data,
+            uncertainties,
+            simulation,
+            # Enable estimation of hessian diagonal if jacobian is a linop
+            estimate_hessian_diagonal=jacobian_as_linop,
+        )
         # Get approximated hessian
         model = self.rng.uniform(size=self.n_params)
         hessian_approx = data_misfit.hessian_approx(model)

--- a/tests/test_data_misfit.py
+++ b/tests/test_data_misfit.py
@@ -95,6 +95,45 @@ class TestDataMisfit:
             data_misfit.hessian(model), data_misfit.hessian_approx(model)
         )
 
+    @pytest.mark.parametrize(
+        "jacobian_as_linop", [False, True], ids=["dense-jac", "linop-jac"]
+    )
+    def test_hessian_diagonal(
+        self, data_and_uncertainties, regressor_matrix, jacobian_as_linop
+    ):
+        """
+        Test the ``hessian_diagonal`` method.
+        """
+        data, uncertainties = data_and_uncertainties
+
+        # Define data misfit
+        simulation = LinearRegressor(regressor_matrix, linop=jacobian_as_linop)
+        data_misfit = DataMisfit(
+            data,
+            uncertainties,
+            simulation,
+            # Enable estimation of hessian diagonal if jacobian is a linop
+            estimate_hessian_diagonal=jacobian_as_linop,
+        )
+
+        # Get diagonal of the hessian
+        model = self.rng.uniform(size=self.n_params)
+        hessian_diagonal = data_misfit.hessian_diagonal(model)
+
+        # Compare with expected one
+        expected = (
+            DataMisfit(
+                data,
+                uncertainties,
+                simulation=LinearRegressor(regressor_matrix),
+                build_hessian=True,
+            )
+            .hessian(model)
+            .diagonal()
+        )
+
+        np.testing.assert_allclose(hessian_diagonal, expected)
+
     def test_hessian_error(self, data_and_uncertainties, regressor_matrix):
         """
         Test error if `build_hessian` is True and Jacobian is a linear operator.


### PR DESCRIPTION
Equip objective functions with the `hessian_approx` and the `hessian_diagonal` methods. The former returns a dense or sparse matrix that approximates the Hessian, while the latter returns a 1D array with the diagonal of the Hessian. Update and extend tests.
