### PR TITLE
Return null objects if `multiplier` is equal to zero

### DIFF
--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -11,7 +11,7 @@ from typing import Self
 
 import numpy as np
 import numpy.typing as npt
-from scipy.sparse import spmatrix, csr_array
+from scipy.sparse import csr_array, spmatrix
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 from ..typing import HasDiagonal, Model, SparseArray

--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -11,7 +11,7 @@ from typing import Self
 
 import numpy as np
 import numpy.typing as npt
-from scipy.sparse import spmatrix
+from scipy.sparse import spmatrix, csr_array
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 from ..typing import HasDiagonal, Model, SparseArray
@@ -229,12 +229,16 @@ class Scaled(Objective):
         """
         Evaluate the objective function.
         """
+        if self.multiplier == 0.0:
+            return self.multiplier
         return self.multiplier * self.function(model)
 
     def gradient(self, model: Model) -> npt.NDArray[np.float64]:
         """
         Evaluate the gradient of the objective function for a given model.
         """
+        if self.multiplier == 0.0:
+            return np.zeros(self.n_params, dtype=np.float64)
         return self.multiplier * self.function.gradient(model)
 
     def hessian(
@@ -243,12 +247,21 @@ class Scaled(Objective):
         """
         Evaluate the hessian of the objective function for a given model.
         """
+        if self.multiplier == 0.0:
+            # TODO: replace this with a Zero operator?
+            shape = (self.n_params, self.n_params)
+            return csr_array(shape, dtype=np.float64)
         return self.multiplier * self.function.hessian(model)
 
     def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
+        if self.multiplier == 0.0:
+            shape = (self.n_params, self.n_params)
+            return csr_array(shape, dtype=np.float64)
         return self.multiplier * self.function.hessian_approx(model)
 
     def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
+        if self.multiplier == 0.0:
+            return np.zeros(self.n_params, dtype=np.float64)
         return self.multiplier * self.function.hessian_diagonal(model)
 
     def info(self):

--- a/tests/base/test_objective_functions.py
+++ b/tests/base/test_objective_functions.py
@@ -746,6 +746,49 @@ class TestScaledMethods:
             self.scalar * phi.hessian_diagonal(model),
         )
 
+    # TODO:
+    # add a Failed objective function that will throw errors when calling its methods.
+    # This way we can make sure that these test don't call the underlying function.
+    def test_call_null(self, model):
+        """Test calling a Scaled with a zero multiplier."""
+        phi = Dummy(self.n_params)
+        scaled = 0.0 * phi
+        result = scaled(model)
+        assert np.isscalar(result)
+        assert result == 0.0
+
+    def test_gradient_null(self, model):
+        """Test gradient of Scaled with a zero multiplier."""
+        phi = Dummy(self.n_params)
+        scaled = 0.0 * phi
+        gradient = scaled.gradient(model)
+        assert gradient.shape == (self.n_params,)
+        np.testing.assert_equal(gradient, 0.0)
+
+    def test_hessian_null(self, model):
+        """Test hessian of Scaled with a zero multiplier."""
+        phi = Dummy(self.n_params)
+        scaled = 0.0 * phi
+        hessian = scaled.hessian(model)
+        assert hessian.shape == (self.n_params, self.n_params)
+        np.testing.assert_equal(hessian.toarray(), 0.0)
+
+    def test_hessian_approx_null(self, model):
+        """Test hessian_approx of Scaled with a zero multiplier."""
+        phi = Dummy(self.n_params)
+        scaled = 0.0 * phi
+        hessian_approx = scaled.hessian_approx(model)
+        assert hessian_approx.shape == (self.n_params, self.n_params)
+        np.testing.assert_equal(hessian_approx.toarray(), 0.0)
+
+    def test_hessian_diagonal_null(self, model):
+        """Test hessian_diagonal of Scaled with a zero multiplier."""
+        phi = Dummy(self.n_params)
+        scaled = 0.0 * phi
+        hessian_diagonal = scaled.hessian_diagonal(model)
+        assert hessian_diagonal.shape == (self.n_params,)
+        np.testing.assert_equal(hessian_diagonal, 0.0)
+
 
 class TestObjectiveFunRepresentations:
     """

--- a/tests/base/test_objective_functions.py
+++ b/tests/base/test_objective_functions.py
@@ -678,6 +678,37 @@ class TestComboMethods:
         )
 
 
+class Failed(Objective):
+    """
+    A failed objective function that raises errors on every method.
+
+    This class is used to test that ``Scaled`` methods don't call the underlying
+    objective function methods if the ``multiplier`` is zero.
+    """
+
+    def __init__(self, n_params: int):
+        self._n_params = n_params
+
+    @property
+    def n_params(self):
+        return self._n_params
+
+    def __call__(self, model):
+        raise NotImplementedError()
+
+    def gradient(self, model):
+        raise NotImplementedError()
+
+    def hessian(self, model):
+        raise NotImplementedError()
+
+    def hessian_approx(self, model):
+        raise NotImplementedError()
+
+    def hessian_diagonal(self, model):
+        raise NotImplementedError()
+
+
 class TestScaledMethods:
     """
     Test ``__call__``, ``gradient`` and ``hessian`` for a ``Scaled``.
@@ -746,12 +777,12 @@ class TestScaledMethods:
             self.scalar * phi.hessian_diagonal(model),
         )
 
-    # TODO:
-    # add a Failed objective function that will throw errors when calling its methods.
-    # This way we can make sure that these test don't call the underlying function.
     def test_call_null(self, model):
         """Test calling a Scaled with a zero multiplier."""
-        phi = Dummy(self.n_params)
+        phi = Failed(self.n_params)
+        with pytest.raises(NotImplementedError):
+            phi(model)
+
         scaled = 0.0 * phi
         result = scaled(model)
         assert np.isscalar(result)
@@ -759,7 +790,10 @@ class TestScaledMethods:
 
     def test_gradient_null(self, model):
         """Test gradient of Scaled with a zero multiplier."""
-        phi = Dummy(self.n_params)
+        phi = Failed(self.n_params)
+        with pytest.raises(NotImplementedError):
+            phi.gradient(model)
+
         scaled = 0.0 * phi
         gradient = scaled.gradient(model)
         assert gradient.shape == (self.n_params,)
@@ -767,7 +801,10 @@ class TestScaledMethods:
 
     def test_hessian_null(self, model):
         """Test hessian of Scaled with a zero multiplier."""
-        phi = Dummy(self.n_params)
+        phi = Failed(self.n_params)
+        with pytest.raises(NotImplementedError):
+            phi.hessian(model)
+
         scaled = 0.0 * phi
         hessian = scaled.hessian(model)
         assert hessian.shape == (self.n_params, self.n_params)
@@ -775,7 +812,10 @@ class TestScaledMethods:
 
     def test_hessian_approx_null(self, model):
         """Test hessian_approx of Scaled with a zero multiplier."""
-        phi = Dummy(self.n_params)
+        phi = Failed(self.n_params)
+        with pytest.raises(NotImplementedError):
+            phi.hessian_approx(model)
+
         scaled = 0.0 * phi
         hessian_approx = scaled.hessian_approx(model)
         assert hessian_approx.shape == (self.n_params, self.n_params)
@@ -783,7 +823,10 @@ class TestScaledMethods:
 
     def test_hessian_diagonal_null(self, model):
         """Test hessian_diagonal of Scaled with a zero multiplier."""
-        phi = Dummy(self.n_params)
+        phi = Failed(self.n_params)
+        with pytest.raises(NotImplementedError):
+            phi.hessian_diagonal(model)
+
         scaled = 0.0 * phi
         hessian_diagonal = scaled.hessian_diagonal(model)
         assert hessian_diagonal.shape == (self.n_params,)


### PR DESCRIPTION
Prevent `Scaled` objective function to trigger the computation of the underlying methods if the `multiplier` is strictly equal to zero. Extend tests.

Fixes #66
