### PR TITLE
Use xxhash for hashing models in decorator

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,8 @@ dependencies:
   - simpeg==0.25.2
   - pymatsolver==0.4.0
   - discretize==0.12.0
+  # Optional dependencies
+  - python-xxhash
   # Required by notebooks
   - harmonica
   - verde

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "discretize==0.12.0",
 ]
 
+[project.optional-dependencies]
+xxhash = ["xxhash"]
+
 [build-system]
 requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ scipy-stubs
 discretize==0.12.0
 simpeg==0.25.2
 pymatsolver==0.4.0
+xxhash

--- a/src/inversion_ideas/utils.py
+++ b/src/inversion_ideas/utils.py
@@ -3,7 +3,6 @@ Utility functions.
 """
 
 import functools
-import hashlib
 import logging
 
 import numpy as np
@@ -11,6 +10,16 @@ import numpy.typing as npt
 
 from ._utils import array_to_str
 from .typing import SparseArray
+
+try:
+    import xxhash
+except ImportError:
+    import hashlib
+
+    HASHING_FUNCTION = hashlib.sha256
+else:
+    HASHING_FUNCTION = xxhash.xxh32
+
 
 __all__ = [
     "cache_on_model",
@@ -110,7 +119,7 @@ def cache_on_model(func):
             raise AttributeError(msg)
 
         if self.cache:
-            model_hash = hashlib.sha256(model)
+            model_hash = HASHING_FUNCTION(model)
 
             # Return cached object if the model hash matches with the cached one
             if hasattr(self, cache_attr):
@@ -136,7 +145,8 @@ def cache_on_model(func):
             # -- Debug log --
             msg = (
                 f"Computed new result '{array_to_str(result)}' after "
-                f"calling '{func}' with model with hash '{model_hash.hexdigest()}'. "
+                f"calling '{func}' with model with hash "
+                f"'{model_hash.name}:{model_hash.hexdigest()}'. "
                 "Cached the result into the object."
             )
             if args:


### PR DESCRIPTION
Add `xxhash` as optional dependency. Use `xxh32` as hashing function if `xxhash` is installed.

Fixes #62


TODO: 

- [ ] Fix conflicts: move the new function to the decorators submodule and fix conflicts.
- [ ] Add a way to get the default hashing function, update hashing in `WrappedSimulation` (WIP to solve #146)