### PR TITLE
Remove `Objective.__init__` abstract method

### DIFF
--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -27,10 +27,6 @@ class Objective(ABC):
     _base_str = "φ"
     _base_latex = r"\phi"
 
-    @abstractmethod
-    def __init__(self):
-        pass  # pragma: no cover
-
     @property
     @abstractmethod
     def n_params(self) -> int:


### PR DESCRIPTION
The interface for objective functions doesn't require them to have an `__init__` method. Even though all of our objective function classes will implement them, there's no need to force its requirement.
