### PR TITLE
Generate description of `__call__` method in Sphinx

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -22,6 +22,14 @@ Methods
 
 .. rubric:: Methods documentation
 
+{% for item in members %}
+{% if item == '__call__' %}
+.. automethod:: {{ objname }}.{{ item }}
+
+----
+{% endif %}
+{% endfor %}
+
 {% for item in methods %}
 {% if item != '__init__' %}
 .. automethod:: {{ objname }}.{{ item }}


### PR DESCRIPTION
Document the `__call__` method of a class in Sphinx.
