### PR TITLE
Remove the `hessian_approx` method

### DIFF
--- a/src/inversion_ideas/base/objective_function.py
+++ b/src/inversion_ideas/base/objective_function.py
@@ -82,29 +82,6 @@ class Objective(ABC):
             raise TypeError(msg)
         return hessian.diagonal()
 
-    def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
-        """
-        Approximated version of the Hessian.
-
-        Parameters
-        ----------
-        model : (n_params) array
-            Array with model values.
-
-        Returns
-        -------
-        (n_params, n_params) array or sparse array
-            2D array that approximates the Hessian of the objective function.
-        """
-        hessian = self.hessian(model)
-        if isinstance(hessian, LinearOperator):
-            msg = (
-                f"Cannot build a 'hessian_approx' for objective function '{self}', "
-                "since its Hessian is a LinearOperator."
-            )
-            raise TypeError(msg)
-        return hessian
-
     @property
     def name(self) -> str | None:
         """
@@ -253,12 +230,6 @@ class Scaled(Objective):
             return csr_array(shape, dtype=np.float64)
         return self.multiplier * self.function.hessian(model)
 
-    def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
-        if self.multiplier == 0.0:
-            shape = (self.n_params, self.n_params)
-            return csr_array(shape, dtype=np.float64)
-        return self.multiplier * self.function.hessian_approx(model)
-
     def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
         if self.multiplier == 0.0:
             return np.zeros(self.n_params, dtype=np.float64)
@@ -387,9 +358,6 @@ class Combo(Objective):
         Evaluate the hessian of the objective function for a given model.
         """
         return _sum_operators(f.hessian(model) for f in self.functions)
-
-    def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
-        return _sum_operators(f.hessian_approx(model) for f in self.functions)
 
     def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
         return sum(

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -37,12 +37,12 @@ class DataMisfit(Objective):
             you need to build it.
 
     estimate_hessian_diagonal : bool, optional
-        If True, the ``hessian_diagonal`` and the ``hessian_approx`` methods will
-        estimate the diagonal of the Hessian, even if the Jacobian of the ``simulation``
-        is a :class:`~scipy.sparse.linalg.LinearOperator`.
-        If False, an error will be raised when calling the ``hessian_diagonal`` or the
-        ``hessian_approx`` methods in case the Jacobian of the ``simulation`` is
-        a :class:`~scipy.sparse.linalg.LinearOperator`.
+        If True, the ``hessian_diagonal`` method will estimate the
+        diagonal of the Hessian, even if the Jacobian of the ``simulation`` is a
+        :class:`~scipy.sparse.linalg.LinearOperator`.
+        If False, an error will be raised when calling the ``hessian_diagonal`` method
+        in case the Jacobian of the ``simulation`` is a
+        :class:`~scipy.sparse.linalg.LinearOperator`.
 
         .. important::
 
@@ -146,43 +146,6 @@ class DataMisfit(Objective):
             jac = aslinearoperator(jac)
         weights_matrix = aslinearoperator(self.weights_matrix)
         return 2 * jac.T @ weights_matrix.T @ weights_matrix @ jac
-
-    def hessian_approx(self, model: Model) -> npt.NDArray[np.float64] | SparseArray:
-        """
-        Approximated version of the Hessian.
-
-        If ``build_hessian`` is True, then the full Hessian will be returned.
-        Otherwise, the Hessian will be approximated by a diagonal sparse matrix, whose
-        main diagonal matches Hessian's diagonal.
-
-        .. important::
-
-            If the Jacobian of the ``simulation`` is
-            a :class:`~scipy.sparse.linalg.LinearOperator`, the diagonal of the Hessian
-            will be estimated only if ``estimate_hessian_diagonal`` is True.
-            Diagonal estimations can be expensive computational tasks for large
-            problems. Make sure you to enable diagonal estimations only if you need it.
-
-        Parameters
-        ----------
-        model : (n_params) array
-            Array with model values.
-
-        Returns
-        -------
-        (n_params, n_params) dense or sparse array
-            2D diagonal dense or sparse array that approximates the Hessian of the
-            objective function.
-
-        See Also
-        --------
-        DataMisfit.hessian_diagonal
-        """
-        if self.build_hessian:
-            # Ignore type error: if build_hessian is True, then hessian(model) will
-            # always return a dense or sparse array.
-            return self.hessian(model)  # type: ignore[return-value]
-        return diags_array(self.hessian_diagonal(model))
 
     def hessian_diagonal(self, model: Model) -> npt.NDArray[np.float64]:
         """

--- a/tests/base/test_objective_functions.py
+++ b/tests/base/test_objective_functions.py
@@ -311,9 +311,9 @@ class TestObjectiveOperations:
         assert combo != sum(collection).flatten()
 
 
-class TestObjectiveHessian:
+class TestObjectiveHessianDiagonal:
     """
-    Test the default implementation of ``hessian_approx`` and ``hessian_diagonal``.
+    Test the default implementation of ``hessian_diagonal``.
     """
 
     n_params = 5
@@ -323,23 +323,6 @@ class TestObjectiveHessian:
         rng = np.random.default_rng(seed=42)
         model = rng.uniform(size=self.n_params)
         return model
-
-    @pytest.mark.parametrize("hessian_type", ["dense", "sparse"])
-    def test_hessian_approx(self, model, hessian_type):
-        """
-        Test if the default implementation of ``hessian_approx`` returns the Hessian.
-        """
-        phi = Dummy(3, seed=42, hessian_type=hessian_type)
-        assert_equal_linear_operators(phi.hessian(model), phi.hessian_approx(model))
-
-    def test_hessian_approx_linop_error(self, model):
-        """
-        Test error on ``hessian_approx`` if hessian is a LinearOperator.
-        """
-        phi = Dummy(3, seed=42, hessian_type="linop")
-        msg = re.escape("Cannot build a 'hessian_approx' for objective function")
-        with pytest.raises(TypeError, match=msg):
-            phi.hessian_approx(model)
 
     @pytest.mark.parametrize("hessian_type", ["dense", "sparse"])
     def test_hessian_diagonal(self, model, hessian_type):
@@ -568,30 +551,6 @@ class TestComboMethods:
             )
         ],
     )
-    def test_hessian_approx(self, model, hessian_types):
-        """
-        Test the hessian_approx method of Combo objective functions.
-        """
-        type_a, type_b = hessian_types
-        rng = np.random.default_rng(seed=42)
-        phi_a = Dummy(self.n_params, seed=rng, hessian_type=type_a)
-        phi_b = Dummy(self.n_params, seed=rng, hessian_type=type_b)
-        combo = phi_a + phi_b
-        assert_equal_linear_operators(
-            combo.hessian_approx(model),
-            phi_a.hessian_approx(model) + phi_b.hessian_approx(model),
-            to_dense=True,
-        )
-
-    @pytest.mark.parametrize(
-        "hessian_types",
-        [
-            pytest.param((type_a, type_b), id=f"{type_a}-{type_b}")
-            for type_a, type_b in itertools.combinations_with_replacement(
-                ("dense", "sparse"), 2
-            )
-        ],
-    )
     def test_hessian_diagonal(self, model, hessian_types):
         """
         Test the hessian_diagonal method of Combo objective functions.
@@ -629,9 +588,6 @@ class Failed(Objective):
         raise NotImplementedError()
 
     def hessian(self, model):
-        raise NotImplementedError()
-
-    def hessian_approx(self, model):
         raise NotImplementedError()
 
     def hessian_diagonal(self, model):
@@ -682,19 +638,6 @@ class TestScaledMethods:
         )
 
     @pytest.mark.parametrize("hessian_type", ["dense", "sparse"])
-    def test_hessian_approx(self, model, hessian_type):
-        """
-        Test the ``hessian_approx`` method of Scaled objective functions.
-        """
-        phi = Dummy(self.n_params, seed=42, hessian_type=hessian_type)
-        scaled = self.scalar * phi
-        assert_equal_linear_operators(
-            scaled.hessian_approx(model),
-            self.scalar * phi.hessian_approx(model),
-            to_dense=True,
-        )
-
-    @pytest.mark.parametrize("hessian_type", ["dense", "sparse"])
     def test_hessian_diagonal(self, model, hessian_type):
         """
         Test the ``hessian_diagonal`` method of Scaled objective functions.
@@ -738,17 +681,6 @@ class TestScaledMethods:
         hessian = scaled.hessian(model)
         assert hessian.shape == (self.n_params, self.n_params)
         np.testing.assert_equal(hessian.toarray(), 0.0)
-
-    def test_hessian_approx_null(self, model):
-        """Test hessian_approx of Scaled with a zero multiplier."""
-        phi = Failed(self.n_params)
-        with pytest.raises(NotImplementedError):
-            phi.hessian_approx(model)
-
-        scaled = 0.0 * phi
-        hessian_approx = scaled.hessian_approx(model)
-        assert hessian_approx.shape == (self.n_params, self.n_params)
-        np.testing.assert_equal(hessian_approx.toarray(), 0.0)
 
     def test_hessian_diagonal_null(self, model):
         """Test hessian_diagonal of Scaled with a zero multiplier."""

--- a/tests/test_data_misfit.py
+++ b/tests/test_data_misfit.py
@@ -6,7 +6,6 @@ import re
 
 import numpy as np
 import pytest
-import scipy.sparse as sp
 
 from inversion_ideas import DataMisfit
 
@@ -42,58 +41,6 @@ class TestDataMisfit:
     def regressor_matrix(self):
         shape = (self.n_data, self.n_params)
         return self.rng.uniform(size=self.n_data * self.n_params).reshape(shape)
-
-    @pytest.mark.parametrize(
-        "jacobian_as_linop", [False, True], ids=["dense-jac", "linop-jac"]
-    )
-    def test_hessian_approx(
-        self, data_and_uncertainties, regressor_matrix, jacobian_as_linop
-    ):
-        """
-        Test the ``hessian_approx`` method.
-        """
-        data, uncertainties = data_and_uncertainties
-
-        # Define data misfit
-        simulation = LinearRegressor(regressor_matrix, linop=jacobian_as_linop)
-        data_misfit = DataMisfit(
-            data,
-            uncertainties,
-            simulation,
-            # Enable estimation of hessian diagonal if jacobian is a linop
-            estimate_hessian_diagonal=jacobian_as_linop,
-        )
-        # Get approximated hessian
-        model = self.rng.uniform(size=self.n_params)
-        hessian_approx = data_misfit.hessian_approx(model)
-
-        # Compare with expected one
-        full_hessian = DataMisfit(
-            data,
-            uncertainties,
-            simulation=LinearRegressor(regressor_matrix),
-            build_hessian=True,
-        ).hessian(model)
-        expected = sp.diags_array(full_hessian.diagonal())
-        assert_allclose_linear_operators(hessian_approx, expected, to_dense=True)
-
-    def test_hessian_approx_with_dense_hessian(
-        self, data_and_uncertainties, regressor_matrix
-    ):
-        """
-        Test that ``hessian_approx`` returns the Hessian if ``build_hessian``.
-        """
-        data, uncertainties = data_and_uncertainties
-
-        # Define data misfit
-        simulation = LinearRegressor(regressor_matrix)
-        data_misfit = DataMisfit(data, uncertainties, simulation, build_hessian=True)
-
-        # Test if hessian and hessian_approx are the same
-        model = self.rng.uniform(size=self.n_params)
-        np.testing.assert_equal(
-            data_misfit.hessian(model), data_misfit.hessian_approx(model)
-        )
 
     @pytest.mark.parametrize(
         "jacobian_as_linop", [False, True], ids=["dense-jac", "linop-jac"]


### PR DESCRIPTION
Remove the `hessian_approx` method from objective functions. We didn't have any real use case for it, it might create confusion with the `hessian` method (that most of the times returns an approximated version of the hessian matrix), and it caused incompatibilities hard to circumvent with the model slicers we aim to include to support joint inversions.


Fix #107
