### PR TITLE
Fix new Ruff rule

### DIFF
--- a/src/inversion_ideas/inversion.py
+++ b/src/inversion_ideas/inversion.py
@@ -266,7 +266,7 @@ class Inversion:
         return self._log_minimizers and isinstance(self.minimizer, Minimizer)
 
     @property
-    def minimizer_logs(self) -> list[None | MinimizerLog] | None:
+    def minimizer_logs(self) -> list[MinimizerLog | None] | None:
         """
         Logs of minimizers.
         """


### PR DESCRIPTION
Fix new RUF036 rule that warns against not listing `None` at the end of a union.
