### PR TITLE
Remove `Simulation.__init__` abstract method

### DIFF
--- a/src/inversion_ideas/base/simulation.py
+++ b/src/inversion_ideas/base/simulation.py
@@ -16,10 +16,6 @@ class Simulation(ABC):
     Abstract representation of a simulation.
     """
 
-    @abstractmethod
-    def __init__(self):
-        pass
-
     @property
     @abstractmethod
     def n_params(self) -> int:


### PR DESCRIPTION
Remove the `__init__` abstract method in the base `Simulation` class. Even though many simulation classes will have their own `__init__` method, there's no need to enforce it from the base abstract class.
