### PR TITLE
Add a new `decorators` submodule

### DIFF
--- a/docs/reference/decorators.rst
+++ b/docs/reference/decorators.rst
@@ -1,0 +1,14 @@
+.. _api.decorators:
+
+.. currentmodule:: inversion_ideas
+
+Decorators
+==========
+
+.. autosummary::
+   :toctree: api/
+
+   decorators
+   decorators.cache_on_model
+   decorators.debug
+   decorators.CountCalls

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -18,5 +18,6 @@ API Reference
    inversion
    operators
    utils
+   decorators
    errors
    base

--- a/docs/reference/utils.rst
+++ b/docs/reference/utils.rst
@@ -9,6 +9,6 @@ Utilities
    :toctree: api/
 
    utils
-   utils.cache_on_model
    utils.get_logger
    utils.get_sensitivity_weights
+   utils.Counter

--- a/notebooks/regressor.py
+++ b/notebooks/regressor.py
@@ -9,7 +9,7 @@ from numpy.typing import NDArray
 from scipy.sparse.linalg import LinearOperator
 
 from inversion_ideas.base import Simulation
-from inversion_ideas.utils import cache_on_model
+from inversion_ideas.decorators import cache_on_model
 
 
 class LinearRegressor(Simulation):

--- a/src/inversion_ideas/__init__.py
+++ b/src/inversion_ideas/__init__.py
@@ -2,7 +2,7 @@
 Ideas for inversion framework.
 """
 
-from . import base, conditions, directives, errors, operators, typing, utils
+from . import base, conditions, decorators, directives, errors, operators, typing, utils
 from ._version import __version__
 from .data_misfit import DataMisfit
 from .inversion import Inversion
@@ -39,6 +39,7 @@ __all__ = [
     "create_l2_inversion",
     "create_sparse_inversion",
     "create_tikhonov_regularization",
+    "decorators",
     "directives",
     "errors",
     "get_jacobi_preconditioner",

--- a/src/inversion_ideas/decorators.py
+++ b/src/inversion_ideas/decorators.py
@@ -1,0 +1,151 @@
+"""
+Decorators for functions, methods and classes.
+"""
+
+import functools
+import hashlib
+
+from ._utils import array_to_str
+from .utils import get_logger
+
+
+def cache_on_model(func):
+    """
+    Cache the last result of a method within the instance using the model hash.
+
+    .. important::
+
+        Use this decorator only for methods that take the ``model`` as the first
+        argument.
+
+    .. important::
+
+        The instance needs to have a ``cache`` bool attribute. If True, the result
+        of the decorated method will be cached. If False, no caching will be performed.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>>
+    >>> class MyClass:
+    ...
+    ...     def __init__(self):
+    ...         self.cache = True
+    ...
+    ...     @cache_on_model
+    ...     def squared(self, model) -> float:
+    ...         return (model ** 2).sum()
+    >>>
+    >>> sq = MyClass()
+    >>> model = np.array([1.0, 2.0, 3.0])
+    >>> print(sq.squared(model))  # perform the computation
+    14.0
+    >>> print(sq.squared(model))  # access the cached result
+    14.0
+
+    >>> model_new = np.array([4.0, 5.0, 6.0])
+    >>> print(sq.squared(model_new))  # perform a new computation
+    77.0
+    """
+    # Define attribute name for the cached result using the hash of the function
+    cache_attr = f"_cache_{hash(func)}"
+
+    @functools.wraps(func)
+    def wrapper(self, model, *args, **kwargs):
+        if not hasattr(self, "cache"):
+            msg = f"Missing 'cache' attribute in {self}"
+            raise AttributeError(msg)
+
+        if self.cache:
+            model_hash = hashlib.sha256(model)
+
+            # Return cached object if the model hash matches with the cached one
+            if hasattr(self, cache_attr):
+                model_hash_cached, cached_result = getattr(self, cache_attr)
+                if model_hash_cached.digest() == model_hash.digest():
+                    # -- Debug log --
+                    msg = (
+                        f"Returning cached object '{array_to_str(cached_result)}' "
+                        f"after calling '{func}' with model with hash "
+                        f"'{model_hash_cached.hexdigest()}'."
+                    )
+                    if args:
+                        msg += f" With args: '{args}'."
+                    if kwargs:
+                        msg += f" With kwargs: '{kwargs}'."
+                    get_logger().debug(msg)
+                    # ---
+                    return cached_result
+
+            # Compute new result and cache it
+            result = func(self, model, *args, **kwargs)
+            setattr(self, cache_attr, (model_hash, result))
+            # -- Debug log --
+            msg = (
+                f"Computed new result '{array_to_str(result)}' after "
+                f"calling '{func}' with model with hash '{model_hash.hexdigest()}'. "
+                "Cached the result into the object."
+            )
+            if args:
+                msg += f" With args: '{args}'."
+            if kwargs:
+                msg += f" With kwargs: '{kwargs}'."
+            get_logger().debug(msg)
+            # ---
+            return result
+
+        # Return result without caching
+        return func(self, model, *args, **kwargs)
+
+    return wrapper
+
+
+def debug(func):
+    """
+    Add a debug entry into the logger through a decorator.
+
+    Use this decorator on methods and functions. When such method or function gets
+    called, it will add an entry into the logger as a DEBUG level.
+    """
+    logger = get_logger()
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        msg = f"Called '{func}'"
+        if args:
+            msg += f" with arguments '{args}'"
+        if kwargs:
+            msg += f" with keyword arguments '{kwargs}'"
+        msg += "."
+        logger.debug(msg)
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+class CountCalls:
+    """
+    Class decorator to count function calls.
+
+    Examples
+    --------
+    >>> @CountCalls
+    ... def my_function(x):
+    ...     return x**2
+    >>> my_function(1)
+    1
+    >>> my_function(2)
+    4
+    >>> my_function.counts
+    2
+    """
+
+    def __init__(self, func):
+        functools.update_wrapper(self, func)
+        self.func = func
+        self.counts = 0
+
+    def __call__(self, *args, **kwargs):
+        result = self.func(*args, **kwargs)
+        self.counts += 1
+        return result

--- a/src/inversion_ideas/inversion.py
+++ b/src/inversion_ideas/inversion.py
@@ -18,10 +18,12 @@ from rich.tree import Tree
 
 from inversion_ideas.errors import ConvergenceWarning
 
+from ._utils import array_to_str
 from .base import Condition, Directive, Minimizer, Objective
+from .decorators import debug
 from .inversion_log import InversionLog, InversionLogRich, MinimizerLog
 from .typing import Log, Model
-from .utils import array_to_str, debug, get_logger
+from .utils import get_logger
 
 
 class Inversion:

--- a/src/inversion_ideas/minimize/_minimizers.py
+++ b/src/inversion_ideas/minimize/_minimizers.py
@@ -10,9 +10,10 @@ import numpy as np
 from scipy.sparse.linalg import cg
 
 from ..base import Condition, Minimizer, MinimizerResult, Objective
+from ..decorators import CountCalls
 from ..errors import ConvergenceWarning
 from ..typing import CanBeUpdated, Model, Preconditioner
-from ..utils import CountCalls, Counter, get_logger
+from ..utils import Counter, get_logger
 from ._utils import backtracking_line_search
 
 

--- a/src/inversion_ideas/simulations.py
+++ b/src/inversion_ideas/simulations.py
@@ -7,8 +7,8 @@ import numpy.typing as npt
 from scipy.sparse.linalg import LinearOperator
 
 from .base import Simulation
+from .decorators import cache_on_model
 from .typing import Model
-from .utils import cache_on_model
 
 
 def wrap_simulation(simulation, *, store_jacobian=False):

--- a/src/inversion_ideas/utils.py
+++ b/src/inversion_ideas/utils.py
@@ -2,18 +2,15 @@
 Utility functions.
 """
 
-import functools
-import hashlib
 import logging
 
 import numpy as np
 import numpy.typing as npt
 
-from ._utils import array_to_str
 from .typing import SparseArray
 
 __all__ = [
-    "cache_on_model",
+    "Counter",
     "get_logger",
     "get_sensitivity_weights",
 ]
@@ -60,120 +57,6 @@ def get_logger():
     >>> logger.setLevel("DEBUG")
     """
     return LOGGER
-
-
-def cache_on_model(func):
-    """
-    Cache the last result of a method within the instance using the model hash.
-
-    .. important::
-
-        Use this decorator only for methods that take the ``model`` as the first
-        argument.
-
-    .. important::
-
-        The instance needs to have a ``cache`` bool attribute. If True, the result
-        of the decorated method will be cached. If False, no caching will be performed.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>>
-    >>> class MyClass:
-    ...
-    ...     def __init__(self):
-    ...         self.cache = True
-    ...
-    ...     @cache_on_model
-    ...     def squared(self, model) -> float:
-    ...         return (model ** 2).sum()
-    >>>
-    >>> sq = MyClass()
-    >>> model = np.array([1.0, 2.0, 3.0])
-    >>> print(sq.squared(model))  # perform the computation
-    14.0
-    >>> print(sq.squared(model))  # access the cached result
-    14.0
-
-    >>> model_new = np.array([4.0, 5.0, 6.0])
-    >>> print(sq.squared(model_new))  # perform a new computation
-    77.0
-    """
-    # Define attribute name for the cached result using the hash of the function
-    cache_attr = f"_cache_{hash(func)}"
-
-    @functools.wraps(func)
-    def wrapper(self, model, *args, **kwargs):
-        if not hasattr(self, "cache"):
-            msg = f"Missing 'cache' attribute in {self}"
-            raise AttributeError(msg)
-
-        if self.cache:
-            model_hash = hashlib.sha256(model)
-
-            # Return cached object if the model hash matches with the cached one
-            if hasattr(self, cache_attr):
-                model_hash_cached, cached_result = getattr(self, cache_attr)
-                if model_hash_cached.digest() == model_hash.digest():
-                    # -- Debug log --
-                    msg = (
-                        f"Returning cached object '{array_to_str(cached_result)}' "
-                        f"after calling '{func}' with model with hash "
-                        f"'{model_hash_cached.hexdigest()}'."
-                    )
-                    if args:
-                        msg += f" With args: '{args}'."
-                    if kwargs:
-                        msg += f" With kwargs: '{kwargs}'."
-                    get_logger().debug(msg)
-                    # ---
-                    return cached_result
-
-            # Compute new result and cache it
-            result = func(self, model, *args, **kwargs)
-            setattr(self, cache_attr, (model_hash, result))
-            # -- Debug log --
-            msg = (
-                f"Computed new result '{array_to_str(result)}' after "
-                f"calling '{func}' with model with hash '{model_hash.hexdigest()}'. "
-                "Cached the result into the object."
-            )
-            if args:
-                msg += f" With args: '{args}'."
-            if kwargs:
-                msg += f" With kwargs: '{kwargs}'."
-            get_logger().debug(msg)
-            # ---
-            return result
-
-        # Return result without caching
-        return func(self, model, *args, **kwargs)
-
-    return wrapper
-
-
-def debug(func):
-    """
-    Add a debug entry into the logger through a decorator.
-
-    Use this decorator on methods and functions. When such method or function gets
-    called, it will add an entry into the logger as a DEBUG level.
-    """
-    logger = get_logger()
-
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        msg = f"Called '{func}'"
-        if args:
-            msg += f" with arguments '{args}'"
-        if kwargs:
-            msg += f" with keyword arguments '{kwargs}'"
-        msg += "."
-        logger.debug(msg)
-        return func(self, *args, **kwargs)
-
-    return wrapper
 
 
 def get_sensitivity_weights(
@@ -265,31 +148,3 @@ class Counter:
             Keyword arguments that will be ignored.
         """
         self._counts += 1
-
-
-class CountCalls:
-    """
-    Class decorator to count function calls.
-
-    Examples
-    --------
-    >>> @CountCalls
-    ... def my_function(x):
-    ...     return x**2
-    >>> my_function(1)
-    1
-    >>> my_function(2)
-    4
-    >>> my_function.counts
-    2
-    """
-
-    def __init__(self, func):
-        functools.update_wrapper(self, func)
-        self.func = func
-        self.counts = 0
-
-    def __call__(self, *args, **kwargs):
-        result = self.func(*args, **kwargs)
-        self.counts += 1
-        return result

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,8 +8,8 @@ from scipy.sparse import dia_array, sparray
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 from inversion_ideas.base import Objective, Simulation
+from inversion_ideas.decorators import cache_on_model
 from inversion_ideas.typing import SparseArray
-from inversion_ideas.utils import cache_on_model
 
 
 class Dummy(Objective):


### PR DESCRIPTION
Move all decorators functions and classes from `inversion_ideas.utils` to `inversion_ideas.decorators`. Add decorators to API reference.

Fixes #132