### PR TITLE
Add sanity checks to inputs of `DataMisfit`

### DIFF
--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -163,12 +163,10 @@ class DataMisfit(Objective):
                 f"argument with {simulation.n_data} 'n_params'. "
             )
             raise ValueError(msg)
-        if np.any(np.isnan(data)):
-            msg = "Invalid `data` array with NaN values."
-            raise ValueError(msg)
-        if np.any(np.isnan(uncertainty)):
-            msg = "Invalid `uncertainty` array with NaN values."
-            raise ValueError(msg)
+        for name, array in {"data": data, "uncertainty": uncertainty}.items():
+            if np.any(np.isnan(array) | np.isinf(array)):
+                msg = f"Invalid `{name}` array with NaN values."
+                raise ValueError(msg)
 
         self.data = data
         self.uncertainty = uncertainty

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -11,7 +11,7 @@ from inversion_ideas.utils import get_logger
 
 from .base import Objective, Simulation
 from .operators import get_diagonal
-from .typing import Model, SparseArray
+from .typing import Model, SimulationProtocol, SparseArray
 
 
 class DataMisfit(Objective):
@@ -148,6 +148,14 @@ class DataMisfit(Objective):
                 "It must be a 1D array."
             )
             raise ValueError(msg)
+        if not isinstance(simulation, SimulationProtocol):
+            msg = (
+                "Invalid `simulation` argument of type "
+                f"'{type(simulation).__name__}'. "
+                "It must be a child of `inversion_ideas.base.Simulation` or "
+                "a custom object that implements its interface."
+            )
+            raise TypeError(msg)
         if not (simulation.n_data == data.size == uncertainty.size):
             msg = (
                 f"Invalid `data` and `uncertainty` arguments with {data.size} and "

--- a/src/inversion_ideas/data_misfit.py
+++ b/src/inversion_ideas/data_misfit.py
@@ -9,7 +9,7 @@ from scipy.sparse.linalg import LinearOperator, aslinearoperator
 
 from inversion_ideas.utils import get_logger
 
-from .base import Objective
+from .base import Objective, Simulation
 from .operators import get_diagonal
 from .typing import Model, SparseArray
 
@@ -130,13 +130,38 @@ class DataMisfit(Objective):
         self,
         data: npt.NDArray[np.float64],
         uncertainty: npt.NDArray[np.float64],
-        simulation,
+        simulation: Simulation,
         *,
         build_hessian=False,
         estimate_hessian_diagonal=False,
     ):
-        # TODO: Check that the data and uncertainties have the size as ndata in the
-        #       simulation.
+        # Validate inputs
+        if data.ndim != 1:
+            msg = (
+                f"Invalid `data` array with {data.ndim} dimensions. "
+                "It must be a 1D array."
+            )
+            raise ValueError(msg)
+        if uncertainty.ndim != 1:
+            msg = (
+                f"Invalid `uncertainty` array with {uncertainty.ndim} dimensions. "
+                "It must be a 1D array."
+            )
+            raise ValueError(msg)
+        if not (simulation.n_data == data.size == uncertainty.size):
+            msg = (
+                f"Invalid `data` and `uncertainty` arguments with {data.size} and "
+                f"{uncertainty.size} elements, respectively, and `simulation` "
+                f"argument with {simulation.n_data} 'n_params'. "
+            )
+            raise ValueError(msg)
+        if np.any(np.isnan(data)):
+            msg = "Invalid `data` array with NaN values."
+            raise ValueError(msg)
+        if np.any(np.isnan(uncertainty)):
+            msg = "Invalid `uncertainty` array with NaN values."
+            raise ValueError(msg)
+
         self.data = data
         self.uncertainty = uncertainty
         self.simulation = simulation

--- a/src/inversion_ideas/typing.py
+++ b/src/inversion_ideas/typing.py
@@ -42,6 +42,25 @@ class CanBeUpdated(Protocol):
         raise NotImplementedError
 
 
+@runtime_checkable
+class SimulationProtocol(Protocol):
+    """Protocol for simulation objects."""
+
+    @property
+    def n_data(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def n_params(self) -> int:
+        raise NotImplementedError
+
+    def __call__(self, model) -> npt.NDArray[np.float64]:
+        raise NotImplementedError
+
+    def jacobian(self, model) -> npt.NDArray[np.float64] | LinearOperator:
+        raise NotImplementedError
+
+
 class SparseRegularization(Protocol):
     """
     Protocol to define sparse regularizations that can be used with a IRLS algorithm.

--- a/tests/test_data_misfit.py
+++ b/tests/test_data_misfit.py
@@ -40,7 +40,7 @@ class TestDataMisfit:
     @pytest.fixture
     def regressor_matrix(self):
         shape = (self.n_data, self.n_params)
-        return self.rng.uniform(size=self.n_data * self.n_params).reshape(shape)
+        return self.rng.uniform(size=shape)
 
     @pytest.mark.parametrize(
         "jacobian_as_linop", [False, True], ids=["dense-jac", "linop-jac"]
@@ -123,3 +123,76 @@ class TestDataMisfit:
         assert_allclose_linear_operators(
             data_misfit.hessian(model), data_misfit_test.hessian(model)
         )
+
+
+class TestSanityChecks:
+    """Test sanity checks for arguments of ``DataMisfit``."""
+
+    rng = np.random.default_rng(seed=42)
+    n_data = 25
+    n_params = 30
+
+    @pytest.fixture
+    def regressor_matrix(self):
+        shape = (self.n_data, self.n_params)
+        return self.rng.uniform(size=shape)
+
+    def test_data_not_1d_array(self, regressor_matrix):
+        data_2d = self.rng.uniform(size=self.n_data).reshape((5, 5))
+        uncertainty = self.rng.uniform(size=self.n_data)
+        simulation = LinearRegressor(regressor_matrix)
+        msg = re.escape(
+            "Invalid `data` array with 2 dimensions. It must be a 1D array."
+        )
+        with pytest.raises(ValueError, match=msg):
+            DataMisfit(data_2d, uncertainty, simulation)
+
+    def test_uncertainty_not_1d_array(self, regressor_matrix):
+        data = self.rng.uniform(size=self.n_data)
+        uncertainty_2d = self.rng.uniform(size=self.n_data).reshape((5, 5))
+        simulation = LinearRegressor(regressor_matrix)
+        msg = re.escape(
+            "Invalid `uncertainty` array with 2 dimensions. It must be a 1D array."
+        )
+        with pytest.raises(ValueError, match=msg):
+            DataMisfit(data, uncertainty_2d, simulation)
+
+    @pytest.mark.parametrize("offending", ["data", "uncertainty", "simulation"])
+    def test_wrong_size(self, offending, regressor_matrix):
+        if offending == "simulation":
+            x = self.rng.uniform(size=(self.n_data + 1, self.n_params))
+            simulation = LinearRegressor(x)
+            data = self.rng.uniform(size=self.n_data)
+            uncertainty = self.rng.uniform(size=self.n_data)
+        elif offending == "data":
+            data = self.rng.uniform(size=self.n_data + 1)
+            uncertainty = self.rng.uniform(size=self.n_data)
+            simulation = LinearRegressor(regressor_matrix)
+        elif offending == "uncertainty":
+            data = self.rng.uniform(size=self.n_data)
+            uncertainty = self.rng.uniform(size=self.n_data + 1)
+            simulation = LinearRegressor(regressor_matrix)
+        else:
+            raise ValueError()
+        msg = re.escape(
+            f"Invalid `data` and `uncertainty` arguments with {data.size} and "
+            f"{uncertainty.size} elements, respectively, and `simulation` "
+            f"argument with {simulation.n_data} 'n_params'. "
+        )
+        with pytest.raises(ValueError, match=msg):
+            DataMisfit(data, uncertainty, simulation)
+
+    @pytest.mark.parametrize("offending", ["data", "uncertainty"])
+    def test_nans(self, offending, regressor_matrix):
+        data = self.rng.uniform(size=self.n_data)
+        uncertainty = self.rng.uniform(size=self.n_data)
+        simulation = LinearRegressor(regressor_matrix)
+        if offending == "data":
+            data[5] = np.nan
+        elif offending == "uncertainty":
+            uncertainty[5] = np.nan
+        else:
+            raise ValueError()
+        msg = re.escape(f"Invalid `{offending}` array with NaN values.")
+        with pytest.raises(ValueError, match=msg):
+            DataMisfit(data, uncertainty, simulation)

--- a/tests/test_data_misfit.py
+++ b/tests/test_data_misfit.py
@@ -196,3 +196,28 @@ class TestSanityChecks:
         msg = re.escape(f"Invalid `{offending}` array with NaN values.")
         with pytest.raises(ValueError, match=msg):
             DataMisfit(data, uncertainty, simulation)
+
+    def test_invalid_simulation(self):
+        class NonSimulation:
+            """
+            Dummy class that doesn't implement the full interface of a Simulation.
+            """
+
+            @property
+            def n_params(self):
+                return 30
+
+            @property
+            def n_data(self):
+                return 25
+
+            def __call__(self, model):
+                pass
+
+        data = self.rng.uniform(size=self.n_data)
+        uncertainty = self.rng.uniform(size=self.n_data)
+        simulation = NonSimulation()
+
+        msg = re.escape("Invalid `simulation` argument of type 'NonSimulation'.")
+        with pytest.raises(TypeError, match=msg):
+            DataMisfit(data, uncertainty, simulation)

--- a/tests/test_data_misfit.py
+++ b/tests/test_data_misfit.py
@@ -157,18 +157,18 @@ class TestSanityChecks:
         with pytest.raises(ValueError, match=msg):
             DataMisfit(data, uncertainty_2d, simulation)
 
-    @pytest.mark.parametrize("offending", ["data", "uncertainty", "simulation"])
-    def test_wrong_size(self, offending, regressor_matrix):
-        if offending == "simulation":
+    @pytest.mark.parametrize("offending_arg", ["data", "uncertainty", "simulation"])
+    def test_wrong_size(self, offending_arg, regressor_matrix):
+        if offending_arg == "simulation":
             x = self.rng.uniform(size=(self.n_data + 1, self.n_params))
             simulation = LinearRegressor(x)
             data = self.rng.uniform(size=self.n_data)
             uncertainty = self.rng.uniform(size=self.n_data)
-        elif offending == "data":
+        elif offending_arg == "data":
             data = self.rng.uniform(size=self.n_data + 1)
             uncertainty = self.rng.uniform(size=self.n_data)
             simulation = LinearRegressor(regressor_matrix)
-        elif offending == "uncertainty":
+        elif offending_arg == "uncertainty":
             data = self.rng.uniform(size=self.n_data)
             uncertainty = self.rng.uniform(size=self.n_data + 1)
             simulation = LinearRegressor(regressor_matrix)
@@ -182,18 +182,21 @@ class TestSanityChecks:
         with pytest.raises(ValueError, match=msg):
             DataMisfit(data, uncertainty, simulation)
 
-    @pytest.mark.parametrize("offending", ["data", "uncertainty"])
-    def test_nans(self, offending, regressor_matrix):
+    @pytest.mark.parametrize("invalid_value", [np.nan, np.inf, "both"])
+    @pytest.mark.parametrize("offending_arg", ["data", "uncertainty"])
+    def test_nans_or_infs(self, invalid_value, offending_arg, regressor_matrix):
         data = self.rng.uniform(size=self.n_data)
         uncertainty = self.rng.uniform(size=self.n_data)
         simulation = LinearRegressor(regressor_matrix)
-        if offending == "data":
-            data[5] = np.nan
-        elif offending == "uncertainty":
-            uncertainty[5] = np.nan
+
+        # Contaminate offending argument with nan, inf, or both
+        array = data if offending_arg == "data" else uncertainty
+        if invalid_value == "both":
+            array[4], array[5] = np.nan, np.inf
         else:
-            raise ValueError()
-        msg = re.escape(f"Invalid `{offending}` array with NaN values.")
+            array[5] = invalid_value
+
+        msg = re.escape(f"Invalid `{offending_arg}` array with NaN values.")
         with pytest.raises(ValueError, match=msg):
             DataMisfit(data, uncertainty, simulation)
 


### PR DESCRIPTION
Raise errors if the `data` and `uncertainty` arrays are not 1D and if they contain any `np.nan` or `np.inf`. Raise error if `simulation.n_data` is not equal to the number of elements in the two arrays. Add tests for the new tests.

Fix #108
